### PR TITLE
Add canonical nuggets and storage blocks

### DIFF
--- a/src/main/java/com/unifyworks/UnifyWorks.java
+++ b/src/main/java/com/unifyworks/UnifyWorks.java
@@ -1,7 +1,10 @@
 package com.unifyworks;
 
-import net.neoforged.fml.common.Mod;
+import com.unifyworks.data.MaterialsIndex;
+import com.unifyworks.registry.UWBlocks;
+import com.unifyworks.registry.UWItems;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 
 @Mod(UnifyWorks.MODID)
@@ -9,12 +12,17 @@ public class UnifyWorks {
     public static final String MODID = "unifyworks";
 
     public UnifyWorks(IEventBus modBus) {
-        // TODO: Register deferred registries for items/blocks if needed
-        // TODO: Hook data reload listeners for materials + compression config
+        // bootstrap registries from data snapshot before freeze
+        var snap = MaterialsIndex.loadBootstrap();
+        UWItems.bootstrap(snap.metals, snap.gems);
+        UWBlocks.bootstrap(snap.metals, snap.gems);
+        UWItems.ITEMS.register(modBus);
+        UWBlocks.BLOCKS.register(modBus);
+
         modBus.addListener(this::onCommonSetup);
     }
 
     private void onCommonSetup(final FMLCommonSetupEvent event) {
-        // TODO: Initialize services (recipe unifier, loot modifiers registration, IMC, etc.)
+        // future: recipe unifier, loot hooks, compression, worldgen wiring
     }
 }

--- a/src/main/java/com/unifyworks/data/MaterialsIndex.java
+++ b/src/main/java/com/unifyworks/data/MaterialsIndex.java
@@ -1,0 +1,35 @@
+package com.unifyworks.data;
+
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Minimal bootstrap reader for materials.json before registries freeze. */
+public class MaterialsIndex {
+    public static class Snapshot {
+        public final List<String> metals = new ArrayList<>();
+        public final List<String> gems = new ArrayList<>();
+    }
+
+    public static Snapshot loadBootstrap() {
+        Snapshot snap = new Snapshot();
+        try {
+            var url = MaterialsIndex.class.getClassLoader().getResource("data/unifyworks/unify/materials.json");
+            if (url == null) return snap;
+            try (var in = new InputStreamReader(url.openStream())) {
+                var root = com.google.gson.JsonParser.parseReader(in).getAsJsonObject();
+                var arr = root.getAsJsonArray("materials");
+                for (var el : arr) {
+                    var obj = el.getAsJsonObject();
+                    String name = obj.get("name").getAsString();
+                    String kind = obj.get("kind").getAsString();
+                    boolean nugget = obj.has("provide_nugget") && obj.get("provide_nugget").getAsBoolean();
+                    boolean block = obj.has("provide_storage_block") && obj.get("provide_storage_block").getAsBoolean();
+                    if ("metal".equals(kind) && (nugget || block)) snap.metals.add(name);
+                    if ("gem".equals(kind) && (nugget || block)) snap.gems.add(name);
+                }
+            }
+        } catch (Exception ignored) {}
+        return snap;
+    }
+}

--- a/src/main/java/com/unifyworks/datagen/UWRecipeProvider.java
+++ b/src/main/java/com/unifyworks/datagen/UWRecipeProvider.java
@@ -1,0 +1,80 @@
+package com.unifyworks.datagen;
+
+import com.unifyworks.UnifyWorks;
+import com.unifyworks.data.MaterialsIndex;
+import com.unifyworks.registry.UWBlocks;
+import com.unifyworks.registry.UWItems;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.recipes.RecipeCategory;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.RecipeProvider;
+import net.minecraft.data.recipes.ShapedRecipeBuilder;
+import net.minecraft.data.recipes.ShapelessRecipeBuilder;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+
+import java.util.concurrent.CompletableFuture;
+
+/** Generates 9 nuggets <-> 1 base, and 9 base <-> 1 storage block. */
+public class UWRecipeProvider extends RecipeProvider {
+    public UWRecipeProvider(PackOutput output, CompletableFuture<net.minecraft.core.HolderLookup.Provider> registries) {
+        super(output, registries);
+    }
+
+    @Override
+    protected void buildRecipes(RecipeOutput out) {
+        var snap = MaterialsIndex.loadBootstrap();
+
+        for (var m : snap.metals) {
+            Item nugget = UWItems.NUGGETS.get(m).get();
+            Item ingot = UWItems.BASE_ITEMS.get(m).get();
+            Block block = UWBlocks.STORAGE_BLOCKS.get(m).get();
+
+            ShapedRecipeBuilder.shaped(RecipeCategory.MISC, ingot)
+                    .define('#', nugget).pattern("###").pattern("###").pattern("###")
+                    .unlockedBy("has_nugget", has(nugget))
+                    .save(out, UnifyWorks.MODID + ":ingot_from_nuggets/" + m);
+
+            ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, nugget, 9)
+                    .requires(ingot)
+                    .unlockedBy("has_ingot", has(ingot))
+                    .save(out, UnifyWorks.MODID + ":nuggets_from_ingot/" + m);
+
+            ShapedRecipeBuilder.shaped(RecipeCategory.BUILDING_BLOCKS, block)
+                    .define('#', ingot).pattern("###").pattern("###").pattern("###")
+                    .unlockedBy("has_ingot", has(ingot))
+                    .save(out, UnifyWorks.MODID + ":block_from_ingots/" + m);
+
+            ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, ingot, 9)
+                    .requires(block)
+                    .unlockedBy("has_block", has(block))
+                    .save(out, UnifyWorks.MODID + ":ingots_from_block/" + m);
+        }
+
+        for (var g : snap.gems) {
+            Item nugget = UWItems.NUGGETS.get(g).get();
+            Item gem = UWItems.BASE_ITEMS.get(g).get();
+            Block block = UWBlocks.STORAGE_BLOCKS.get(g).get();
+
+            ShapedRecipeBuilder.shaped(RecipeCategory.MISC, gem)
+                    .define('#', nugget).pattern("###").pattern("###").pattern("###")
+                    .unlockedBy("has_nugget", has(nugget))
+                    .save(out, UnifyWorks.MODID + ":gem_from_nuggets/" + g);
+
+            ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, nugget, 9)
+                    .requires(gem)
+                    .unlockedBy("has_gem", has(gem))
+                    .save(out, UnifyWorks.MODID + ":nuggets_from_gem/" + g);
+
+            ShapedRecipeBuilder.shaped(RecipeCategory.BUILDING_BLOCKS, block)
+                    .define('#', gem).pattern("###").pattern("###").pattern("###")
+                    .unlockedBy("has_gem", has(gem))
+                    .save(out, UnifyWorks.MODID + ":block_from_gems/" + g);
+
+            ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, gem, 9)
+                    .requires(block)
+                    .unlockedBy("has_block", has(block))
+                    .save(out, UnifyWorks.MODID + ":gems_from_block/" + g);
+        }
+    }
+}

--- a/src/main/java/com/unifyworks/registry/UWBlocks.java
+++ b/src/main/java/com/unifyworks/registry/UWBlocks.java
@@ -1,0 +1,49 @@
+package com.unifyworks.registry;
+
+import com.unifyworks.UnifyWorks;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.MapColor;
+import net.neoforged.neoforge.registries.DeferredBlock;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Canonical storage blocks for metals and gems. */
+public class UWBlocks {
+    public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(UnifyWorks.MODID);
+    public static final Map<String, DeferredBlock<Block>> STORAGE_BLOCKS = new HashMap<>();
+
+    public static void bootstrap(List<String> metals, List<String> gems) {
+        STORAGE_BLOCKS.clear();
+        for (String m : metals) {
+            DeferredBlock<Block> block = BLOCKS.register(m + "_block", () -> new Block(metalStorageProps()));
+            STORAGE_BLOCKS.put(m, block);
+            UWItems.ITEMS.registerSimpleBlockItem(block);
+        }
+        for (String g : gems) {
+            DeferredBlock<Block> block = BLOCKS.register(g + "_block", () -> new Block(gemStorageProps()));
+            STORAGE_BLOCKS.put(g, block);
+            UWItems.ITEMS.registerSimpleBlockItem(block);
+        }
+    }
+
+    private static BlockBehaviour.Properties metalStorageProps() {
+        return BlockBehaviour.Properties.of()
+                .mapColor(MapColor.METAL)
+                .strength(5.0F, 6.0F)
+                .requiresCorrectToolForDrops()
+                .sound(SoundType.METAL);
+    }
+
+    private static BlockBehaviour.Properties gemStorageProps() {
+        return BlockBehaviour.Properties.of()
+                .mapColor(MapColor.COLOR_LIGHT_BLUE)
+                .strength(5.0F, 6.0F)
+                .requiresCorrectToolForDrops()
+                .sound(SoundType.AMETHYST);
+    }
+}

--- a/src/main/java/com/unifyworks/registry/UWItems.java
+++ b/src/main/java/com/unifyworks/registry/UWItems.java
@@ -1,0 +1,31 @@
+package com.unifyworks.registry;
+
+import com.unifyworks.UnifyWorks;
+import net.minecraft.world.item.Item;
+import net.neoforged.neoforge.registries.DeferredItem;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Canonical items: nuggets and base items (ingot/gem). */
+public class UWItems {
+    public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(UnifyWorks.MODID);
+
+    public static final Map<String, DeferredItem<Item>> NUGGETS = new HashMap<>();
+    public static final Map<String, DeferredItem<Item>> BASE_ITEMS = new HashMap<>(); // ingot or gem
+
+    public static void bootstrap(List<String> metals, List<String> gems) {
+        NUGGETS.clear();
+        BASE_ITEMS.clear();
+        for (String m : metals) {
+            NUGGETS.put(m, ITEMS.register("nugget_" + m, () -> new Item(new Item.Properties())));
+            BASE_ITEMS.put(m, ITEMS.register(m + "_ingot", () -> new Item(new Item.Properties())));
+        }
+        for (String g : gems) {
+            NUGGETS.put(g, ITEMS.register("nugget_" + g, () -> new Item(new Item.Properties())));
+            BASE_ITEMS.put(g, ITEMS.register(g + "_gem", () -> new Item(new Item.Properties())));
+        }
+    }
+}

--- a/src/main/resources/data/unifyworks/unify/materials.json
+++ b/src/main/resources/data/unifyworks/unify/materials.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "materials": [
     {
       "name": "aluminum",
@@ -11,6 +11,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/aluminum",
@@ -23,6 +25,10 @@
         "ingot": [
           "forge:ingots/aluminum",
           "c:ingots/aluminum"
+        ],
+        "nugget": [
+          "forge:nuggets/aluminum",
+          "c:nuggets/aluminum"
         ],
         "dust": [
           "forge:dusts/aluminum",
@@ -44,6 +50,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/apatite",
@@ -52,6 +60,10 @@
         "gem": [
           "forge:gems/apatite",
           "c:gems/apatite"
+        ],
+        "nugget": [
+          "forge:nuggets/apatite",
+          "c:nuggets/apatite"
         ],
         "dust": [
           "forge:dusts/apatite",
@@ -73,6 +85,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/bronze",
@@ -85,6 +99,10 @@
         "ingot": [
           "forge:ingots/bronze",
           "c:ingots/bronze"
+        ],
+        "nugget": [
+          "forge:nuggets/bronze",
+          "c:nuggets/bronze"
         ],
         "dust": [
           "forge:dusts/bronze",
@@ -103,6 +121,8 @@
       "unify": true,
       "generate_ore": false,
       "variants": {},
+      "provide_storage_block": false,
+      "provide_nugget": false,
       "tags": {
         "any": [
           "forge:charcoal",
@@ -120,6 +140,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/constantan",
@@ -132,6 +154,10 @@
         "ingot": [
           "forge:ingots/constantan",
           "c:ingots/constantan"
+        ],
+        "nugget": [
+          "forge:nuggets/constantan",
+          "c:nuggets/constantan"
         ],
         "dust": [
           "forge:dusts/constantan",
@@ -153,6 +179,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/copper",
@@ -165,6 +193,10 @@
         "ingot": [
           "forge:ingots/copper",
           "c:ingots/copper"
+        ],
+        "nugget": [
+          "forge:nuggets/copper",
+          "c:nuggets/copper"
         ],
         "dust": [
           "forge:dusts/copper",
@@ -186,6 +218,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/diamond",
@@ -194,6 +228,10 @@
         "gem": [
           "forge:gems/diamond",
           "c:gems/diamond"
+        ],
+        "nugget": [
+          "forge:nuggets/diamond",
+          "c:nuggets/diamond"
         ],
         "dust": [
           "forge:dusts/diamond",
@@ -215,6 +253,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/electrum",
@@ -227,6 +267,10 @@
         "ingot": [
           "forge:ingots/electrum",
           "c:ingots/electrum"
+        ],
+        "nugget": [
+          "forge:nuggets/electrum",
+          "c:nuggets/electrum"
         ],
         "dust": [
           "forge:dusts/electrum",
@@ -248,6 +292,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/gold",
@@ -260,6 +306,10 @@
         "ingot": [
           "forge:ingots/gold",
           "c:ingots/gold"
+        ],
+        "nugget": [
+          "forge:nuggets/gold",
+          "c:nuggets/gold"
         ],
         "dust": [
           "forge:dusts/gold",
@@ -281,6 +331,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/graphite",
@@ -289,6 +341,10 @@
         "gem": [
           "forge:gems/graphite",
           "c:gems/graphite"
+        ],
+        "nugget": [
+          "forge:nuggets/graphite",
+          "c:nuggets/graphite"
         ],
         "dust": [
           "forge:dusts/graphite",
@@ -310,6 +366,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/invar",
@@ -322,6 +380,10 @@
         "ingot": [
           "forge:ingots/invar",
           "c:ingots/invar"
+        ],
+        "nugget": [
+          "forge:nuggets/invar",
+          "c:nuggets/invar"
         ],
         "dust": [
           "forge:dusts/invar",
@@ -343,6 +405,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/iron",
@@ -355,6 +419,10 @@
         "ingot": [
           "forge:ingots/iron",
           "c:ingots/iron"
+        ],
+        "nugget": [
+          "forge:nuggets/iron",
+          "c:nuggets/iron"
         ],
         "dust": [
           "forge:dusts/iron",
@@ -376,6 +444,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/lead",
@@ -388,6 +458,10 @@
         "ingot": [
           "forge:ingots/lead",
           "c:ingots/lead"
+        ],
+        "nugget": [
+          "forge:nuggets/lead",
+          "c:nuggets/lead"
         ],
         "dust": [
           "forge:dusts/lead",
@@ -409,6 +483,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/lumium",
@@ -421,6 +497,10 @@
         "ingot": [
           "forge:ingots/lumium",
           "c:ingots/lumium"
+        ],
+        "nugget": [
+          "forge:nuggets/lumium",
+          "c:nuggets/lumium"
         ],
         "dust": [
           "forge:dusts/lumium",
@@ -439,6 +519,8 @@
       "unify": true,
       "generate_ore": false,
       "variants": {},
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/netherite",
@@ -451,6 +533,10 @@
         "ingot": [
           "forge:ingots/netherite",
           "c:ingots/netherite"
+        ],
+        "nugget": [
+          "forge:nuggets/netherite",
+          "c:nuggets/netherite"
         ],
         "dust": [
           "forge:dusts/netherite",
@@ -472,6 +558,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/nickel",
@@ -484,6 +572,10 @@
         "ingot": [
           "forge:ingots/nickel",
           "c:ingots/nickel"
+        ],
+        "nugget": [
+          "forge:nuggets/nickel",
+          "c:nuggets/nickel"
         ],
         "dust": [
           "forge:dusts/nickel",
@@ -502,6 +594,8 @@
       "unify": true,
       "generate_ore": false,
       "variants": {},
+      "provide_storage_block": false,
+      "provide_nugget": false,
       "tags": {
         "any": [
           "forge:obsidian",
@@ -519,6 +613,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/osmium",
@@ -531,6 +627,10 @@
         "ingot": [
           "forge:ingots/osmium",
           "c:ingots/osmium"
+        ],
+        "nugget": [
+          "forge:nuggets/osmium",
+          "c:nuggets/osmium"
         ],
         "dust": [
           "forge:dusts/osmium",
@@ -551,6 +651,8 @@
       "variants": {
         "netherrack": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/quartz",
@@ -559,6 +661,10 @@
         "gem": [
           "forge:gems/quartz",
           "c:gems/quartz"
+        ],
+        "nugget": [
+          "forge:nuggets/quartz",
+          "c:nuggets/quartz"
         ],
         "dust": [
           "forge:dusts/quartz",
@@ -577,6 +683,8 @@
       "unify": true,
       "generate_ore": false,
       "variants": {},
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/refined_glowstone",
@@ -589,6 +697,10 @@
         "ingot": [
           "forge:ingots/refined_glowstone",
           "c:ingots/refined_glowstone"
+        ],
+        "nugget": [
+          "forge:nuggets/refined_glowstone",
+          "c:nuggets/refined_glowstone"
         ],
         "dust": [
           "forge:dusts/refined_glowstone",
@@ -610,6 +722,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": false,
+      "provide_nugget": false,
       "tags": {
         "ore": [
           "forge:ores/signalum",
@@ -622,6 +736,10 @@
         "ingot": [
           "forge:ingots/signalum",
           "c:ingots/signalum"
+        ],
+        "nugget": [
+          "forge:nuggets/signalum",
+          "c:nuggets/signalum"
         ],
         "dust": [
           "forge:dusts/signalum",
@@ -643,6 +761,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/silver",
@@ -655,6 +775,10 @@
         "ingot": [
           "forge:ingots/silver",
           "c:ingots/silver"
+        ],
+        "nugget": [
+          "forge:nuggets/silver",
+          "c:nuggets/silver"
         ],
         "dust": [
           "forge:dusts/silver",
@@ -676,6 +800,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/steel",
@@ -688,6 +814,10 @@
         "ingot": [
           "forge:ingots/steel",
           "c:ingots/steel"
+        ],
+        "nugget": [
+          "forge:nuggets/steel",
+          "c:nuggets/steel"
         ],
         "dust": [
           "forge:dusts/steel",
@@ -709,6 +839,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/sulfur",
@@ -717,6 +849,10 @@
         "gem": [
           "forge:gems/sulfur",
           "c:gems/sulfur"
+        ],
+        "nugget": [
+          "forge:nuggets/sulfur",
+          "c:nuggets/sulfur"
         ],
         "dust": [
           "forge:dusts/sulfur",
@@ -738,6 +874,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/tin",
@@ -750,6 +888,10 @@
         "ingot": [
           "forge:ingots/tin",
           "c:ingots/tin"
+        ],
+        "nugget": [
+          "forge:nuggets/tin",
+          "c:nuggets/tin"
         ],
         "dust": [
           "forge:dusts/tin",
@@ -771,6 +913,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/uranium",
@@ -783,6 +927,10 @@
         "ingot": [
           "forge:ingots/uranium",
           "c:ingots/uranium"
+        ],
+        "nugget": [
+          "forge:nuggets/uranium",
+          "c:nuggets/uranium"
         ],
         "dust": [
           "forge:dusts/uranium",
@@ -804,6 +952,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/zinc",
@@ -816,6 +966,10 @@
         "ingot": [
           "forge:ingots/zinc",
           "c:ingots/zinc"
+        ],
+        "nugget": [
+          "forge:nuggets/zinc",
+          "c:nuggets/zinc"
         ],
         "dust": [
           "forge:dusts/zinc",
@@ -837,6 +991,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/redstone",
@@ -845,6 +1001,10 @@
         "gem": [
           "forge:gems/redstone",
           "c:gems/redstone"
+        ],
+        "nugget": [
+          "forge:nuggets/redstone",
+          "c:nuggets/redstone"
         ],
         "dust": [
           "forge:dusts/redstone",
@@ -866,6 +1026,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/fluorite",
@@ -874,6 +1036,10 @@
         "gem": [
           "forge:gems/fluorite",
           "c:gems/fluorite"
+        ],
+        "nugget": [
+          "forge:nuggets/fluorite",
+          "c:nuggets/fluorite"
         ],
         "dust": [
           "forge:dusts/fluorite",
@@ -895,6 +1061,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/emerald",
@@ -903,6 +1071,10 @@
         "gem": [
           "forge:gems/emerald",
           "c:gems/emerald"
+        ],
+        "nugget": [
+          "forge:nuggets/emerald",
+          "c:nuggets/emerald"
         ],
         "dust": [
           "forge:dusts/emerald",
@@ -924,6 +1096,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/lapis_lazuli",
@@ -932,6 +1106,10 @@
         "gem": [
           "forge:gems/lapis_lazuli",
           "c:gems/lapis_lazuli"
+        ],
+        "nugget": [
+          "forge:nuggets/lapis_lazuli",
+          "c:nuggets/lapis_lazuli"
         ],
         "dust": [
           "forge:dusts/lapis_lazuli",
@@ -953,6 +1131,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/resonating_ore",
@@ -961,6 +1141,10 @@
         "gem": [
           "forge:gems/resonating_ore",
           "c:gems/resonating_ore"
+        ],
+        "nugget": [
+          "forge:nuggets/resonating_ore",
+          "c:nuggets/resonating_ore"
         ],
         "dust": [
           "forge:dusts/resonating_ore",
@@ -982,6 +1166,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/dimensional_shard",
@@ -990,6 +1176,10 @@
         "gem": [
           "forge:gems/dimensional_shard",
           "c:gems/dimensional_shard"
+        ],
+        "nugget": [
+          "forge:nuggets/dimensional_shard",
+          "c:nuggets/dimensional_shard"
         ],
         "dust": [
           "forge:dusts/dimensional_shard",
@@ -1011,6 +1201,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/antimony",
@@ -1023,6 +1215,10 @@
         "ingot": [
           "forge:ingots/antimony",
           "c:ingots/antimony"
+        ],
+        "nugget": [
+          "forge:nuggets/antimony",
+          "c:nuggets/antimony"
         ],
         "dust": [
           "forge:dusts/antimony",
@@ -1044,6 +1240,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": false,
+      "provide_nugget": false,
       "tags": {
         "any": [
           "forge:bauxite",
@@ -1062,6 +1260,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/iridium",
@@ -1074,6 +1274,10 @@
         "ingot": [
           "forge:ingots/iridium",
           "c:ingots/iridium"
+        ],
+        "nugget": [
+          "forge:nuggets/iridium",
+          "c:nuggets/iridium"
         ],
         "dust": [
           "forge:dusts/iridium",
@@ -1095,6 +1299,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/monazite",
@@ -1103,6 +1309,10 @@
         "gem": [
           "forge:gems/monazite",
           "c:gems/monazite"
+        ],
+        "nugget": [
+          "forge:nuggets/monazite",
+          "c:nuggets/monazite"
         ],
         "dust": [
           "forge:dusts/monazite",
@@ -1124,6 +1334,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/tungsten",
@@ -1136,6 +1348,10 @@
         "ingot": [
           "forge:ingots/tungsten",
           "c:ingots/tungsten"
+        ],
+        "nugget": [
+          "forge:nuggets/tungsten",
+          "c:nuggets/tungsten"
         ],
         "dust": [
           "forge:dusts/tungsten",
@@ -1157,6 +1373,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/titanium",
@@ -1169,6 +1387,10 @@
         "ingot": [
           "forge:ingots/titanium",
           "c:ingots/titanium"
+        ],
+        "nugget": [
+          "forge:nuggets/titanium",
+          "c:nuggets/titanium"
         ],
         "dust": [
           "forge:dusts/titanium",
@@ -1190,6 +1412,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/platinum",
@@ -1202,6 +1426,10 @@
         "ingot": [
           "forge:ingots/platinum",
           "c:ingots/platinum"
+        ],
+        "nugget": [
+          "forge:nuggets/platinum",
+          "c:nuggets/platinum"
         ],
         "dust": [
           "forge:dusts/platinum",
@@ -1220,6 +1448,8 @@
       "unify": true,
       "generate_ore": false,
       "variants": {},
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/stainless_steel",
@@ -1232,6 +1462,10 @@
         "ingot": [
           "forge:ingots/stainless_steel",
           "c:ingots/stainless_steel"
+        ],
+        "nugget": [
+          "forge:nuggets/stainless_steel",
+          "c:nuggets/stainless_steel"
         ],
         "dust": [
           "forge:dusts/stainless_steel",
@@ -1250,6 +1484,8 @@
       "unify": true,
       "generate_ore": false,
       "variants": {},
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/plutonium",
@@ -1262,6 +1498,10 @@
         "ingot": [
           "forge:ingots/plutonium",
           "c:ingots/plutonium"
+        ],
+        "nugget": [
+          "forge:nuggets/plutonium",
+          "c:nuggets/plutonium"
         ],
         "dust": [
           "forge:dusts/plutonium",
@@ -1283,6 +1523,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/chromium",
@@ -1295,6 +1537,10 @@
         "ingot": [
           "forge:ingots/chromium",
           "c:ingots/chromium"
+        ],
+        "nugget": [
+          "forge:nuggets/chromium",
+          "c:nuggets/chromium"
         ],
         "dust": [
           "forge:dusts/chromium",
@@ -1316,6 +1562,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/silicon",
@@ -1324,6 +1572,10 @@
         "gem": [
           "forge:gems/silicon",
           "c:gems/silicon"
+        ],
+        "nugget": [
+          "forge:nuggets/silicon",
+          "c:nuggets/silicon"
         ],
         "dust": [
           "forge:dusts/silicon",
@@ -1342,6 +1594,8 @@
       "unify": true,
       "generate_ore": false,
       "variants": {},
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/refined_obsidian",
@@ -1354,6 +1608,10 @@
         "ingot": [
           "forge:ingots/refined_obsidian",
           "c:ingots/refined_obsidian"
+        ],
+        "nugget": [
+          "forge:nuggets/refined_obsidian",
+          "c:nuggets/refined_obsidian"
         ],
         "dust": [
           "forge:dusts/refined_obsidian",
@@ -1375,6 +1633,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/sapphire",
@@ -1383,6 +1643,10 @@
         "gem": [
           "forge:gems/sapphire",
           "c:gems/sapphire"
+        ],
+        "nugget": [
+          "forge:nuggets/sapphire",
+          "c:nuggets/sapphire"
         ],
         "dust": [
           "forge:dusts/sapphire",
@@ -1404,6 +1668,8 @@
         "stone": true,
         "deepslate": true
       },
+      "provide_storage_block": true,
+      "provide_nugget": true,
       "tags": {
         "ore": [
           "forge:ores/ruby",
@@ -1412,6 +1678,10 @@
         "gem": [
           "forge:gems/ruby",
           "c:gems/ruby"
+        ],
+        "nugget": [
+          "forge:nuggets/ruby",
+          "c:nuggets/ruby"
         ],
         "dust": [
           "forge:dusts/ruby",
@@ -1432,12 +1702,12 @@
     "enable_for_items_tags": [
       "forge:ingots",
       "forge:gems",
-      "forge:nuggets",
-      "forge:raw_materials",
       "forge:storage_blocks"
     ],
     "max_tier": 9,
-    "reverse_recipes": true
+    "reverse_recipes": true,
+    "compress_storage_blocks": true,
+    "compress_base_items": true
   },
   "worldgen": {
     "remove_other_mod_ores": true,


### PR DESCRIPTION
## Summary
- bootstrap item and block registries from the materials snapshot and wire them into the mod entrypoint
- add a materials bootstrap reader plus datagen recipes for nugget/base and block conversions
- expand materials.json with nugget & storage block toggles and updated compression metadata

## Testing
- `./gradlew --no-daemon --console=plain --stacktrace --version`
- `./gradlew --no-daemon --console=plain --stacktrace clean build` *(fails: Mojang asset CDN returned multiple HTTP errors during asset download)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4b7f6fac83278a487c7edf016ff0