### PR TITLE
Add scripts for offline Gradle distribution usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ out/
 Thumbs.db
 # Exclude wrapper binary from VCS
 gradle/wrapper/gradle-wrapper.jar
-# Ensure wrapper binary stays untracked
-gradle/wrapper/gradle-wrapper.jar
+# Local offline Gradle cache
+.gradle/local-gradle/

--- a/scripts/bootstrap-offline-gradle.sh
+++ b/scripts/bootstrap-offline-gradle.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+GRADLE_VER="8.14.3"
+DIST_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VER}-bin.zip"
+ZIP_PATH=".gradle/tmp/gradle-${GRADLE_VER}-bin.zip"
+LOCAL_DIR=".gradle/local-gradle/gradle-${GRADLE_VER}"
+
+mkdir -p ".gradle/tmp" ".gradle/local-gradle"
+
+if [ ! -d "${LOCAL_DIR}" ]; then
+  echo "Downloading Gradle ${GRADLE_VER} distribution for offline use..."
+  curl -sSfL "${DIST_URL}" -o "${ZIP_PATH}"
+  echo "Unpacking..."
+  rm -rf "${LOCAL_DIR}"
+  mkdir -p "${LOCAL_DIR}"
+  if command -v unzip >/dev/null 2>&1; then
+    unzip -q "${ZIP_PATH}" -d ".gradle/local-gradle"
+  else
+    python3 - "$ZIP_PATH" <<'PY'
+import sys, zipfile, os
+zip_path = sys.argv[1]
+with zipfile.ZipFile(zip_path) as z:
+    z.extractall(".gradle/local-gradle")
+PY
+  fi
+  # If extracted folder is gradle-<ver>, ensure LOCAL_DIR matches
+  if [ -d ".gradle/local-gradle/gradle-${GRADLE_VER}" ]; then
+    :
+  else
+    echo "Warning: unexpected folder layout under .gradle/local-gradle" >&2
+  fi
+fi
+echo "Offline Gradle ready at ${LOCAL_DIR}"

--- a/scripts/gradle-offline.sh
+++ b/scripts/gradle-offline.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+GRADLE_VER="8.14.3"
+LOCAL_DIR=".gradle/local-gradle/gradle-${GRADLE_VER}"
+if [ ! -x "${LOCAL_DIR}/bin/gradle" ]; then
+  echo "Offline Gradle not found. Run scripts/bootstrap-offline-gradle.sh first." >&2
+  exit 1
+fi
+exec "${LOCAL_DIR}/bin/gradle" "$@"


### PR DESCRIPTION
## Summary
- ensure the local offline Gradle cache is ignored
- add a bootstrap script to download and unpack Gradle 8.14.3
- add a helper script to run the locally unpacked Gradle distribution

## Testing
- bash scripts/bootstrap-offline-gradle.sh
- bash scripts/gradle-offline.sh --version

------
https://chatgpt.com/codex/tasks/task_e_68dd87741d208327a23e4e798bd3588c