### PR TITLE
Add tag-based unification conversions and KubeJS helpers

### DIFF
--- a/DOCS/kubejs_guides.md
+++ b/DOCS/kubejs_guides.md
@@ -1,0 +1,18 @@
+KubeJS guides
+=============
+
+Disable a material entirely
+---------------------------
+Edit `kubejs/startup_scripts/unifyworks.example.js`:
+- Add the material ID (lowercase) to `removeMaterials`.
+- This removes the UnifyWorks canonical outputs at load.
+
+Replace hardcoded inputs with tags
+----------------------------------
+Populate the `replacements` array with `{ from: '<modid:item>', to: '#forge:ingots/<name>' }`, etc.
+This fixes third-party recipes that do not use tags.
+
+Force canonical outputs
+-----------------------
+The sample adds shapeless recipes that convert any tagged item to the canonical item.
+Adjust the metal/gem arrays to match your pack.

--- a/DOCS/unification_strategy.md
+++ b/DOCS/unification_strategy.md
@@ -1,0 +1,11 @@
+Unification strategy
+====================
+- Prefer tag-based inputs across the ecosystem.
+- We do not replace other mods' JSON. Instead, we provide:
+  1) "Any-tag → canonical" shapeless conversions so players can convert foreign items into the unified canonical item.
+  2) Forge and c tags that always include the canonical item.
+  3) KubeJS scripts to remove non-tag recipes and to force canonical outputs.
+
+Limits
+------
+- If a third-party recipe hardcodes an item ID (not a tag), our conversions do not change that recipe. Use the provided KubeJS script to replace it pack-side.

--- a/kubejs/startup_scripts/unifyworks.example.js
+++ b/kubejs/startup_scripts/unifyworks.example.js
@@ -1,0 +1,34 @@
+// KubeJS pack-side helpers for UnifyWorks
+// Copy to kubejs/startup_scripts/ and rename to remove ".example".
+
+ServerEvents.recipes(event => {
+  // 1) Remove specific materials globally
+  // Example: remove tin across items and blocks
+  const removeMaterials = ['tin']; // fill from pack config
+  removeMaterials.forEach(m => {
+    event.remove({ output: RegExp(`^unifyworks:(nugget_${m}|${m}_ingot|${m}_gem|${m}_block)$`) })
+  });
+
+  // 2) Force canonical outputs for tag families
+  const metals = ['iron','copper','gold','silver','lead','tin','nickel','aluminum','uranium','zinc']; // extend
+  const gems   = ['diamond','emerald','ruby','sapphire','lapis_lazuli','fluorite','apatite']; // extend
+
+  metals.forEach(m => {
+    // Any ingot tag -> canonical ingot
+    event.shapeless(Item.of(`unifyworks:${m}_ingot`), [Ingredient.of(`#forge:ingots/${m}`)])
+    // Any nugget tag -> canonical ingot (via 9x crafting already provided)
+    // Any blocks tag -> canonical block if needed
+  });
+
+  gems.forEach(g => {
+    event.shapeless(Item.of(`unifyworks:${g}_gem`), [Ingredient.of(`#forge:gems/${g}`)])
+  });
+
+  // 3) Replace hardcoded inputs in foreign recipes with tag ingredients
+  // Example: replace "othermod:tin_ingot" with "#forge:ingots/tin" across all recipes
+  const replacements = [
+    { from: 'othermod:tin_ingot', to: '#forge:ingots/tin' },
+    { from: 'othermod:ruby', to: '#forge:gems/ruby' },
+  ];
+  replacements.forEach(r => event.replaceInput({}, r.from, Ingredient.of(r.to)));
+});

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/c_dusts_aluminum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/c_dusts_aluminum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/aluminum"}],"result":{"item":"unifyworks:aluminum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/c_ingots_aluminum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/c_ingots_aluminum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/aluminum"}],"result":{"item":"unifyworks:aluminum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/c_nuggets_aluminum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/c_nuggets_aluminum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/aluminum"}],"result":{"item":"unifyworks:aluminum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/c_raw_materials_aluminum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/c_raw_materials_aluminum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/aluminum"}],"result":{"item":"unifyworks:aluminum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/forge_dusts_aluminum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/forge_dusts_aluminum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/aluminum"}],"result":{"item":"unifyworks:aluminum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/forge_ingots_aluminum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/forge_ingots_aluminum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/aluminum"}],"result":{"item":"unifyworks:aluminum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/forge_nuggets_aluminum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/forge_nuggets_aluminum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/aluminum"}],"result":{"item":"unifyworks:aluminum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/forge_raw_materials_aluminum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/aluminum/forge_raw_materials_aluminum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/aluminum"}],"result":{"item":"unifyworks:aluminum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/c_dusts_antimony.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/c_dusts_antimony.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/antimony"}],"result":{"item":"unifyworks:antimony_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/c_ingots_antimony.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/c_ingots_antimony.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/antimony"}],"result":{"item":"unifyworks:antimony_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/c_nuggets_antimony.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/c_nuggets_antimony.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/antimony"}],"result":{"item":"unifyworks:antimony_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/c_raw_materials_antimony.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/c_raw_materials_antimony.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/antimony"}],"result":{"item":"unifyworks:antimony_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/forge_dusts_antimony.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/forge_dusts_antimony.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/antimony"}],"result":{"item":"unifyworks:antimony_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/forge_ingots_antimony.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/forge_ingots_antimony.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/antimony"}],"result":{"item":"unifyworks:antimony_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/forge_nuggets_antimony.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/forge_nuggets_antimony.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/antimony"}],"result":{"item":"unifyworks:antimony_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/forge_raw_materials_antimony.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/antimony/forge_raw_materials_antimony.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/antimony"}],"result":{"item":"unifyworks:antimony_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/c_dusts_apatite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/c_dusts_apatite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/apatite"}],"result":{"item":"unifyworks:apatite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/c_gems_apatite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/c_gems_apatite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/apatite"}],"result":{"item":"unifyworks:apatite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/c_nuggets_apatite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/c_nuggets_apatite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/apatite"}],"result":{"item":"unifyworks:apatite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/forge_dusts_apatite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/forge_dusts_apatite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/apatite"}],"result":{"item":"unifyworks:apatite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/forge_gems_apatite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/forge_gems_apatite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/apatite"}],"result":{"item":"unifyworks:apatite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/forge_nuggets_apatite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/apatite/forge_nuggets_apatite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/apatite"}],"result":{"item":"unifyworks:apatite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/c_dusts_bronze.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/c_dusts_bronze.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/bronze"}],"result":{"item":"unifyworks:bronze_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/c_ingots_bronze.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/c_ingots_bronze.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/bronze"}],"result":{"item":"unifyworks:bronze_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/c_nuggets_bronze.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/c_nuggets_bronze.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/bronze"}],"result":{"item":"unifyworks:bronze_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/c_raw_materials_bronze.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/c_raw_materials_bronze.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/bronze"}],"result":{"item":"unifyworks:bronze_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/forge_dusts_bronze.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/forge_dusts_bronze.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/bronze"}],"result":{"item":"unifyworks:bronze_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/forge_ingots_bronze.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/forge_ingots_bronze.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/bronze"}],"result":{"item":"unifyworks:bronze_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/forge_nuggets_bronze.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/forge_nuggets_bronze.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/bronze"}],"result":{"item":"unifyworks:bronze_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/forge_raw_materials_bronze.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/bronze/forge_raw_materials_bronze.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/bronze"}],"result":{"item":"unifyworks:bronze_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/c_dusts_chromium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/c_dusts_chromium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/chromium"}],"result":{"item":"unifyworks:chromium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/c_ingots_chromium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/c_ingots_chromium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/chromium"}],"result":{"item":"unifyworks:chromium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/c_nuggets_chromium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/c_nuggets_chromium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/chromium"}],"result":{"item":"unifyworks:chromium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/c_raw_materials_chromium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/c_raw_materials_chromium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/chromium"}],"result":{"item":"unifyworks:chromium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/forge_dusts_chromium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/forge_dusts_chromium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/chromium"}],"result":{"item":"unifyworks:chromium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/forge_ingots_chromium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/forge_ingots_chromium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/chromium"}],"result":{"item":"unifyworks:chromium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/forge_nuggets_chromium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/forge_nuggets_chromium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/chromium"}],"result":{"item":"unifyworks:chromium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/forge_raw_materials_chromium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/chromium/forge_raw_materials_chromium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/chromium"}],"result":{"item":"unifyworks:chromium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/c_dusts_constantan.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/c_dusts_constantan.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/constantan"}],"result":{"item":"unifyworks:constantan_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/c_ingots_constantan.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/c_ingots_constantan.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/constantan"}],"result":{"item":"unifyworks:constantan_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/c_nuggets_constantan.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/c_nuggets_constantan.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/constantan"}],"result":{"item":"unifyworks:constantan_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/c_raw_materials_constantan.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/c_raw_materials_constantan.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/constantan"}],"result":{"item":"unifyworks:constantan_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/forge_dusts_constantan.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/forge_dusts_constantan.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/constantan"}],"result":{"item":"unifyworks:constantan_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/forge_ingots_constantan.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/forge_ingots_constantan.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/constantan"}],"result":{"item":"unifyworks:constantan_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/forge_nuggets_constantan.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/forge_nuggets_constantan.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/constantan"}],"result":{"item":"unifyworks:constantan_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/forge_raw_materials_constantan.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/constantan/forge_raw_materials_constantan.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/constantan"}],"result":{"item":"unifyworks:constantan_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/c_dusts_copper.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/c_dusts_copper.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/copper"}],"result":{"item":"unifyworks:copper_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/c_ingots_copper.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/c_ingots_copper.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/copper"}],"result":{"item":"unifyworks:copper_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/c_nuggets_copper.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/c_nuggets_copper.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/copper"}],"result":{"item":"unifyworks:copper_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/c_raw_materials_copper.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/c_raw_materials_copper.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/copper"}],"result":{"item":"unifyworks:copper_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/forge_dusts_copper.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/forge_dusts_copper.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/copper"}],"result":{"item":"unifyworks:copper_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/forge_ingots_copper.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/forge_ingots_copper.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/copper"}],"result":{"item":"unifyworks:copper_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/forge_nuggets_copper.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/forge_nuggets_copper.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/copper"}],"result":{"item":"unifyworks:copper_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/forge_raw_materials_copper.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/copper/forge_raw_materials_copper.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/copper"}],"result":{"item":"unifyworks:copper_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/c_dusts_diamond.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/c_dusts_diamond.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/diamond"}],"result":{"item":"unifyworks:diamond_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/c_gems_diamond.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/c_gems_diamond.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/diamond"}],"result":{"item":"unifyworks:diamond_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/c_nuggets_diamond.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/c_nuggets_diamond.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/diamond"}],"result":{"item":"unifyworks:diamond_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/forge_dusts_diamond.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/forge_dusts_diamond.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/diamond"}],"result":{"item":"unifyworks:diamond_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/forge_gems_diamond.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/forge_gems_diamond.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/diamond"}],"result":{"item":"unifyworks:diamond_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/forge_nuggets_diamond.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/diamond/forge_nuggets_diamond.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/diamond"}],"result":{"item":"unifyworks:diamond_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/c_dusts_dimensional_shard.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/c_dusts_dimensional_shard.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/dimensional_shard"}],"result":{"item":"unifyworks:dimensional_shard_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/c_gems_dimensional_shard.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/c_gems_dimensional_shard.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/dimensional_shard"}],"result":{"item":"unifyworks:dimensional_shard_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/c_nuggets_dimensional_shard.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/c_nuggets_dimensional_shard.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/dimensional_shard"}],"result":{"item":"unifyworks:dimensional_shard_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/forge_dusts_dimensional_shard.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/forge_dusts_dimensional_shard.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/dimensional_shard"}],"result":{"item":"unifyworks:dimensional_shard_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/forge_gems_dimensional_shard.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/forge_gems_dimensional_shard.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/dimensional_shard"}],"result":{"item":"unifyworks:dimensional_shard_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/forge_nuggets_dimensional_shard.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/dimensional_shard/forge_nuggets_dimensional_shard.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/dimensional_shard"}],"result":{"item":"unifyworks:dimensional_shard_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/c_dusts_electrum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/c_dusts_electrum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/electrum"}],"result":{"item":"unifyworks:electrum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/c_ingots_electrum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/c_ingots_electrum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/electrum"}],"result":{"item":"unifyworks:electrum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/c_nuggets_electrum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/c_nuggets_electrum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/electrum"}],"result":{"item":"unifyworks:electrum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/c_raw_materials_electrum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/c_raw_materials_electrum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/electrum"}],"result":{"item":"unifyworks:electrum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/forge_dusts_electrum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/forge_dusts_electrum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/electrum"}],"result":{"item":"unifyworks:electrum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/forge_ingots_electrum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/forge_ingots_electrum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/electrum"}],"result":{"item":"unifyworks:electrum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/forge_nuggets_electrum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/forge_nuggets_electrum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/electrum"}],"result":{"item":"unifyworks:electrum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/forge_raw_materials_electrum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/electrum/forge_raw_materials_electrum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/electrum"}],"result":{"item":"unifyworks:electrum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/c_dusts_emerald.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/c_dusts_emerald.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/emerald"}],"result":{"item":"unifyworks:emerald_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/c_gems_emerald.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/c_gems_emerald.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/emerald"}],"result":{"item":"unifyworks:emerald_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/c_nuggets_emerald.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/c_nuggets_emerald.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/emerald"}],"result":{"item":"unifyworks:emerald_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/forge_dusts_emerald.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/forge_dusts_emerald.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/emerald"}],"result":{"item":"unifyworks:emerald_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/forge_gems_emerald.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/forge_gems_emerald.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/emerald"}],"result":{"item":"unifyworks:emerald_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/forge_nuggets_emerald.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/emerald/forge_nuggets_emerald.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/emerald"}],"result":{"item":"unifyworks:emerald_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/c_dusts_fluorite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/c_dusts_fluorite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/fluorite"}],"result":{"item":"unifyworks:fluorite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/c_gems_fluorite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/c_gems_fluorite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/fluorite"}],"result":{"item":"unifyworks:fluorite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/c_nuggets_fluorite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/c_nuggets_fluorite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/fluorite"}],"result":{"item":"unifyworks:fluorite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/forge_dusts_fluorite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/forge_dusts_fluorite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/fluorite"}],"result":{"item":"unifyworks:fluorite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/forge_gems_fluorite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/forge_gems_fluorite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/fluorite"}],"result":{"item":"unifyworks:fluorite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/forge_nuggets_fluorite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/fluorite/forge_nuggets_fluorite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/fluorite"}],"result":{"item":"unifyworks:fluorite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/c_dusts_gold.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/c_dusts_gold.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/gold"}],"result":{"item":"unifyworks:gold_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/c_ingots_gold.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/c_ingots_gold.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/gold"}],"result":{"item":"unifyworks:gold_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/c_nuggets_gold.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/c_nuggets_gold.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/gold"}],"result":{"item":"unifyworks:gold_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/c_raw_materials_gold.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/c_raw_materials_gold.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/gold"}],"result":{"item":"unifyworks:gold_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/forge_dusts_gold.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/forge_dusts_gold.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/gold"}],"result":{"item":"unifyworks:gold_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/forge_ingots_gold.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/forge_ingots_gold.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/gold"}],"result":{"item":"unifyworks:gold_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/forge_nuggets_gold.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/forge_nuggets_gold.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/gold"}],"result":{"item":"unifyworks:gold_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/forge_raw_materials_gold.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/gold/forge_raw_materials_gold.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/gold"}],"result":{"item":"unifyworks:gold_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/c_dusts_graphite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/c_dusts_graphite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/graphite"}],"result":{"item":"unifyworks:graphite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/c_gems_graphite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/c_gems_graphite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/graphite"}],"result":{"item":"unifyworks:graphite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/c_nuggets_graphite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/c_nuggets_graphite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/graphite"}],"result":{"item":"unifyworks:graphite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/forge_dusts_graphite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/forge_dusts_graphite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/graphite"}],"result":{"item":"unifyworks:graphite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/forge_gems_graphite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/forge_gems_graphite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/graphite"}],"result":{"item":"unifyworks:graphite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/forge_nuggets_graphite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/graphite/forge_nuggets_graphite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/graphite"}],"result":{"item":"unifyworks:graphite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/c_dusts_invar.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/c_dusts_invar.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/invar"}],"result":{"item":"unifyworks:invar_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/c_ingots_invar.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/c_ingots_invar.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/invar"}],"result":{"item":"unifyworks:invar_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/c_nuggets_invar.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/c_nuggets_invar.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/invar"}],"result":{"item":"unifyworks:invar_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/c_raw_materials_invar.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/c_raw_materials_invar.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/invar"}],"result":{"item":"unifyworks:invar_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/forge_dusts_invar.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/forge_dusts_invar.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/invar"}],"result":{"item":"unifyworks:invar_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/forge_ingots_invar.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/forge_ingots_invar.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/invar"}],"result":{"item":"unifyworks:invar_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/forge_nuggets_invar.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/forge_nuggets_invar.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/invar"}],"result":{"item":"unifyworks:invar_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/forge_raw_materials_invar.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/invar/forge_raw_materials_invar.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/invar"}],"result":{"item":"unifyworks:invar_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/c_dusts_iridium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/c_dusts_iridium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/iridium"}],"result":{"item":"unifyworks:iridium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/c_ingots_iridium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/c_ingots_iridium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/iridium"}],"result":{"item":"unifyworks:iridium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/c_nuggets_iridium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/c_nuggets_iridium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/iridium"}],"result":{"item":"unifyworks:iridium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/c_raw_materials_iridium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/c_raw_materials_iridium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/iridium"}],"result":{"item":"unifyworks:iridium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/forge_dusts_iridium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/forge_dusts_iridium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/iridium"}],"result":{"item":"unifyworks:iridium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/forge_ingots_iridium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/forge_ingots_iridium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/iridium"}],"result":{"item":"unifyworks:iridium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/forge_nuggets_iridium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/forge_nuggets_iridium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/iridium"}],"result":{"item":"unifyworks:iridium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/forge_raw_materials_iridium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iridium/forge_raw_materials_iridium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/iridium"}],"result":{"item":"unifyworks:iridium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/c_dusts_iron.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/c_dusts_iron.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/iron"}],"result":{"item":"unifyworks:iron_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/c_ingots_iron.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/c_ingots_iron.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/iron"}],"result":{"item":"unifyworks:iron_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/c_nuggets_iron.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/c_nuggets_iron.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/iron"}],"result":{"item":"unifyworks:iron_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/c_raw_materials_iron.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/c_raw_materials_iron.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/iron"}],"result":{"item":"unifyworks:iron_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/forge_dusts_iron.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/forge_dusts_iron.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/iron"}],"result":{"item":"unifyworks:iron_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/forge_ingots_iron.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/forge_ingots_iron.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/iron"}],"result":{"item":"unifyworks:iron_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/forge_nuggets_iron.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/forge_nuggets_iron.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/iron"}],"result":{"item":"unifyworks:iron_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/forge_raw_materials_iron.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/iron/forge_raw_materials_iron.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/iron"}],"result":{"item":"unifyworks:iron_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/c_dusts_lapis_lazuli.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/c_dusts_lapis_lazuli.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/lapis_lazuli"}],"result":{"item":"unifyworks:lapis_lazuli_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/c_gems_lapis_lazuli.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/c_gems_lapis_lazuli.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/lapis_lazuli"}],"result":{"item":"unifyworks:lapis_lazuli_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/c_nuggets_lapis_lazuli.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/c_nuggets_lapis_lazuli.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/lapis_lazuli"}],"result":{"item":"unifyworks:lapis_lazuli_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/forge_dusts_lapis_lazuli.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/forge_dusts_lapis_lazuli.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/lapis_lazuli"}],"result":{"item":"unifyworks:lapis_lazuli_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/forge_gems_lapis_lazuli.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/forge_gems_lapis_lazuli.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/lapis_lazuli"}],"result":{"item":"unifyworks:lapis_lazuli_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/forge_nuggets_lapis_lazuli.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lapis_lazuli/forge_nuggets_lapis_lazuli.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/lapis_lazuli"}],"result":{"item":"unifyworks:lapis_lazuli_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/c_dusts_lead.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/c_dusts_lead.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/lead"}],"result":{"item":"unifyworks:lead_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/c_ingots_lead.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/c_ingots_lead.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/lead"}],"result":{"item":"unifyworks:lead_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/c_nuggets_lead.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/c_nuggets_lead.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/lead"}],"result":{"item":"unifyworks:lead_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/c_raw_materials_lead.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/c_raw_materials_lead.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/lead"}],"result":{"item":"unifyworks:lead_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/forge_dusts_lead.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/forge_dusts_lead.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/lead"}],"result":{"item":"unifyworks:lead_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/forge_ingots_lead.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/forge_ingots_lead.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/lead"}],"result":{"item":"unifyworks:lead_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/forge_nuggets_lead.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/forge_nuggets_lead.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/lead"}],"result":{"item":"unifyworks:lead_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/forge_raw_materials_lead.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lead/forge_raw_materials_lead.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/lead"}],"result":{"item":"unifyworks:lead_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/c_dusts_lumium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/c_dusts_lumium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/lumium"}],"result":{"item":"unifyworks:lumium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/c_ingots_lumium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/c_ingots_lumium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/lumium"}],"result":{"item":"unifyworks:lumium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/c_nuggets_lumium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/c_nuggets_lumium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/lumium"}],"result":{"item":"unifyworks:lumium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/c_raw_materials_lumium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/c_raw_materials_lumium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/lumium"}],"result":{"item":"unifyworks:lumium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/forge_dusts_lumium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/forge_dusts_lumium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/lumium"}],"result":{"item":"unifyworks:lumium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/forge_ingots_lumium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/forge_ingots_lumium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/lumium"}],"result":{"item":"unifyworks:lumium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/forge_nuggets_lumium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/forge_nuggets_lumium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/lumium"}],"result":{"item":"unifyworks:lumium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/forge_raw_materials_lumium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/lumium/forge_raw_materials_lumium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/lumium"}],"result":{"item":"unifyworks:lumium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/c_dusts_monazite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/c_dusts_monazite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/monazite"}],"result":{"item":"unifyworks:monazite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/c_gems_monazite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/c_gems_monazite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/monazite"}],"result":{"item":"unifyworks:monazite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/c_nuggets_monazite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/c_nuggets_monazite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/monazite"}],"result":{"item":"unifyworks:monazite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/forge_dusts_monazite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/forge_dusts_monazite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/monazite"}],"result":{"item":"unifyworks:monazite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/forge_gems_monazite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/forge_gems_monazite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/monazite"}],"result":{"item":"unifyworks:monazite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/forge_nuggets_monazite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/monazite/forge_nuggets_monazite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/monazite"}],"result":{"item":"unifyworks:monazite_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/c_dusts_netherite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/c_dusts_netherite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/netherite"}],"result":{"item":"unifyworks:netherite_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/c_ingots_netherite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/c_ingots_netherite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/netherite"}],"result":{"item":"unifyworks:netherite_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/c_nuggets_netherite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/c_nuggets_netherite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/netherite"}],"result":{"item":"unifyworks:netherite_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/c_raw_materials_netherite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/c_raw_materials_netherite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/netherite"}],"result":{"item":"unifyworks:netherite_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/forge_dusts_netherite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/forge_dusts_netherite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/netherite"}],"result":{"item":"unifyworks:netherite_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/forge_ingots_netherite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/forge_ingots_netherite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/netherite"}],"result":{"item":"unifyworks:netherite_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/forge_nuggets_netherite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/forge_nuggets_netherite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/netherite"}],"result":{"item":"unifyworks:netherite_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/forge_raw_materials_netherite.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/netherite/forge_raw_materials_netherite.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/netherite"}],"result":{"item":"unifyworks:netherite_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/c_dusts_nickel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/c_dusts_nickel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/nickel"}],"result":{"item":"unifyworks:nickel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/c_ingots_nickel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/c_ingots_nickel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/nickel"}],"result":{"item":"unifyworks:nickel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/c_nuggets_nickel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/c_nuggets_nickel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/nickel"}],"result":{"item":"unifyworks:nickel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/c_raw_materials_nickel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/c_raw_materials_nickel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/nickel"}],"result":{"item":"unifyworks:nickel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/forge_dusts_nickel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/forge_dusts_nickel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/nickel"}],"result":{"item":"unifyworks:nickel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/forge_ingots_nickel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/forge_ingots_nickel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/nickel"}],"result":{"item":"unifyworks:nickel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/forge_nuggets_nickel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/forge_nuggets_nickel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/nickel"}],"result":{"item":"unifyworks:nickel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/forge_raw_materials_nickel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/nickel/forge_raw_materials_nickel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/nickel"}],"result":{"item":"unifyworks:nickel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/c_dusts_osmium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/c_dusts_osmium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/osmium"}],"result":{"item":"unifyworks:osmium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/c_ingots_osmium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/c_ingots_osmium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/osmium"}],"result":{"item":"unifyworks:osmium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/c_nuggets_osmium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/c_nuggets_osmium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/osmium"}],"result":{"item":"unifyworks:osmium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/c_raw_materials_osmium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/c_raw_materials_osmium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/osmium"}],"result":{"item":"unifyworks:osmium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/forge_dusts_osmium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/forge_dusts_osmium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/osmium"}],"result":{"item":"unifyworks:osmium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/forge_ingots_osmium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/forge_ingots_osmium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/osmium"}],"result":{"item":"unifyworks:osmium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/forge_nuggets_osmium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/forge_nuggets_osmium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/osmium"}],"result":{"item":"unifyworks:osmium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/forge_raw_materials_osmium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/osmium/forge_raw_materials_osmium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/osmium"}],"result":{"item":"unifyworks:osmium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/c_dusts_platinum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/c_dusts_platinum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/platinum"}],"result":{"item":"unifyworks:platinum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/c_ingots_platinum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/c_ingots_platinum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/platinum"}],"result":{"item":"unifyworks:platinum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/c_nuggets_platinum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/c_nuggets_platinum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/platinum"}],"result":{"item":"unifyworks:platinum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/c_raw_materials_platinum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/c_raw_materials_platinum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/platinum"}],"result":{"item":"unifyworks:platinum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/forge_dusts_platinum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/forge_dusts_platinum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/platinum"}],"result":{"item":"unifyworks:platinum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/forge_ingots_platinum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/forge_ingots_platinum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/platinum"}],"result":{"item":"unifyworks:platinum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/forge_nuggets_platinum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/forge_nuggets_platinum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/platinum"}],"result":{"item":"unifyworks:platinum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/forge_raw_materials_platinum.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/platinum/forge_raw_materials_platinum.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/platinum"}],"result":{"item":"unifyworks:platinum_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/c_dusts_plutonium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/c_dusts_plutonium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/plutonium"}],"result":{"item":"unifyworks:plutonium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/c_ingots_plutonium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/c_ingots_plutonium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/plutonium"}],"result":{"item":"unifyworks:plutonium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/c_nuggets_plutonium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/c_nuggets_plutonium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/plutonium"}],"result":{"item":"unifyworks:plutonium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/c_raw_materials_plutonium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/c_raw_materials_plutonium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/plutonium"}],"result":{"item":"unifyworks:plutonium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/forge_dusts_plutonium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/forge_dusts_plutonium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/plutonium"}],"result":{"item":"unifyworks:plutonium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/forge_ingots_plutonium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/forge_ingots_plutonium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/plutonium"}],"result":{"item":"unifyworks:plutonium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/forge_nuggets_plutonium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/forge_nuggets_plutonium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/plutonium"}],"result":{"item":"unifyworks:plutonium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/forge_raw_materials_plutonium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/plutonium/forge_raw_materials_plutonium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/plutonium"}],"result":{"item":"unifyworks:plutonium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/c_dusts_quartz.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/c_dusts_quartz.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/quartz"}],"result":{"item":"unifyworks:quartz_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/c_gems_quartz.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/c_gems_quartz.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/quartz"}],"result":{"item":"unifyworks:quartz_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/c_nuggets_quartz.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/c_nuggets_quartz.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/quartz"}],"result":{"item":"unifyworks:quartz_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/forge_dusts_quartz.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/forge_dusts_quartz.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/quartz"}],"result":{"item":"unifyworks:quartz_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/forge_gems_quartz.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/forge_gems_quartz.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/quartz"}],"result":{"item":"unifyworks:quartz_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/forge_nuggets_quartz.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/quartz/forge_nuggets_quartz.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/quartz"}],"result":{"item":"unifyworks:quartz_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/c_dusts_redstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/c_dusts_redstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/redstone"}],"result":{"item":"unifyworks:redstone_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/c_gems_redstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/c_gems_redstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/redstone"}],"result":{"item":"unifyworks:redstone_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/c_nuggets_redstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/c_nuggets_redstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/redstone"}],"result":{"item":"unifyworks:redstone_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/forge_dusts_redstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/forge_dusts_redstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/redstone"}],"result":{"item":"unifyworks:redstone_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/forge_gems_redstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/forge_gems_redstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/redstone"}],"result":{"item":"unifyworks:redstone_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/forge_nuggets_redstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/redstone/forge_nuggets_redstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/redstone"}],"result":{"item":"unifyworks:redstone_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/c_dusts_refined_glowstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/c_dusts_refined_glowstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/refined_glowstone"}],"result":{"item":"unifyworks:refined_glowstone_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/c_ingots_refined_glowstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/c_ingots_refined_glowstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/refined_glowstone"}],"result":{"item":"unifyworks:refined_glowstone_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/c_nuggets_refined_glowstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/c_nuggets_refined_glowstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/refined_glowstone"}],"result":{"item":"unifyworks:refined_glowstone_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/c_raw_materials_refined_glowstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/c_raw_materials_refined_glowstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/refined_glowstone"}],"result":{"item":"unifyworks:refined_glowstone_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/forge_dusts_refined_glowstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/forge_dusts_refined_glowstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/refined_glowstone"}],"result":{"item":"unifyworks:refined_glowstone_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/forge_ingots_refined_glowstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/forge_ingots_refined_glowstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/refined_glowstone"}],"result":{"item":"unifyworks:refined_glowstone_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/forge_nuggets_refined_glowstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/forge_nuggets_refined_glowstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/refined_glowstone"}],"result":{"item":"unifyworks:refined_glowstone_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/forge_raw_materials_refined_glowstone.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_glowstone/forge_raw_materials_refined_glowstone.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/refined_glowstone"}],"result":{"item":"unifyworks:refined_glowstone_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/c_dusts_refined_obsidian.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/c_dusts_refined_obsidian.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/refined_obsidian"}],"result":{"item":"unifyworks:refined_obsidian_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/c_ingots_refined_obsidian.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/c_ingots_refined_obsidian.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/refined_obsidian"}],"result":{"item":"unifyworks:refined_obsidian_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/c_nuggets_refined_obsidian.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/c_nuggets_refined_obsidian.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/refined_obsidian"}],"result":{"item":"unifyworks:refined_obsidian_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/c_raw_materials_refined_obsidian.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/c_raw_materials_refined_obsidian.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/refined_obsidian"}],"result":{"item":"unifyworks:refined_obsidian_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/forge_dusts_refined_obsidian.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/forge_dusts_refined_obsidian.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/refined_obsidian"}],"result":{"item":"unifyworks:refined_obsidian_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/forge_ingots_refined_obsidian.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/forge_ingots_refined_obsidian.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/refined_obsidian"}],"result":{"item":"unifyworks:refined_obsidian_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/forge_nuggets_refined_obsidian.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/forge_nuggets_refined_obsidian.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/refined_obsidian"}],"result":{"item":"unifyworks:refined_obsidian_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/forge_raw_materials_refined_obsidian.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/refined_obsidian/forge_raw_materials_refined_obsidian.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/refined_obsidian"}],"result":{"item":"unifyworks:refined_obsidian_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/c_dusts_resonating_ore.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/c_dusts_resonating_ore.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/resonating_ore"}],"result":{"item":"unifyworks:resonating_ore_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/c_gems_resonating_ore.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/c_gems_resonating_ore.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/resonating_ore"}],"result":{"item":"unifyworks:resonating_ore_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/c_nuggets_resonating_ore.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/c_nuggets_resonating_ore.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/resonating_ore"}],"result":{"item":"unifyworks:resonating_ore_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/forge_dusts_resonating_ore.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/forge_dusts_resonating_ore.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/resonating_ore"}],"result":{"item":"unifyworks:resonating_ore_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/forge_gems_resonating_ore.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/forge_gems_resonating_ore.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/resonating_ore"}],"result":{"item":"unifyworks:resonating_ore_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/forge_nuggets_resonating_ore.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/resonating_ore/forge_nuggets_resonating_ore.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/resonating_ore"}],"result":{"item":"unifyworks:resonating_ore_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/c_dusts_ruby.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/c_dusts_ruby.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/ruby"}],"result":{"item":"unifyworks:ruby_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/c_gems_ruby.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/c_gems_ruby.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/ruby"}],"result":{"item":"unifyworks:ruby_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/c_nuggets_ruby.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/c_nuggets_ruby.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/ruby"}],"result":{"item":"unifyworks:ruby_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/forge_dusts_ruby.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/forge_dusts_ruby.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/ruby"}],"result":{"item":"unifyworks:ruby_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/forge_gems_ruby.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/forge_gems_ruby.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/ruby"}],"result":{"item":"unifyworks:ruby_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/forge_nuggets_ruby.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/ruby/forge_nuggets_ruby.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/ruby"}],"result":{"item":"unifyworks:ruby_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/c_dusts_sapphire.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/c_dusts_sapphire.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/sapphire"}],"result":{"item":"unifyworks:sapphire_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/c_gems_sapphire.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/c_gems_sapphire.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/sapphire"}],"result":{"item":"unifyworks:sapphire_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/c_nuggets_sapphire.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/c_nuggets_sapphire.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/sapphire"}],"result":{"item":"unifyworks:sapphire_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/forge_dusts_sapphire.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/forge_dusts_sapphire.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/sapphire"}],"result":{"item":"unifyworks:sapphire_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/forge_gems_sapphire.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/forge_gems_sapphire.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/sapphire"}],"result":{"item":"unifyworks:sapphire_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/forge_nuggets_sapphire.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sapphire/forge_nuggets_sapphire.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/sapphire"}],"result":{"item":"unifyworks:sapphire_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/c_dusts_silicon.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/c_dusts_silicon.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/silicon"}],"result":{"item":"unifyworks:silicon_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/c_gems_silicon.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/c_gems_silicon.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/silicon"}],"result":{"item":"unifyworks:silicon_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/c_nuggets_silicon.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/c_nuggets_silicon.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/silicon"}],"result":{"item":"unifyworks:silicon_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/forge_dusts_silicon.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/forge_dusts_silicon.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/silicon"}],"result":{"item":"unifyworks:silicon_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/forge_gems_silicon.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/forge_gems_silicon.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/silicon"}],"result":{"item":"unifyworks:silicon_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/forge_nuggets_silicon.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silicon/forge_nuggets_silicon.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/silicon"}],"result":{"item":"unifyworks:silicon_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/c_dusts_silver.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/c_dusts_silver.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/silver"}],"result":{"item":"unifyworks:silver_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/c_ingots_silver.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/c_ingots_silver.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/silver"}],"result":{"item":"unifyworks:silver_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/c_nuggets_silver.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/c_nuggets_silver.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/silver"}],"result":{"item":"unifyworks:silver_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/c_raw_materials_silver.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/c_raw_materials_silver.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/silver"}],"result":{"item":"unifyworks:silver_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/forge_dusts_silver.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/forge_dusts_silver.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/silver"}],"result":{"item":"unifyworks:silver_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/forge_ingots_silver.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/forge_ingots_silver.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/silver"}],"result":{"item":"unifyworks:silver_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/forge_nuggets_silver.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/forge_nuggets_silver.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/silver"}],"result":{"item":"unifyworks:silver_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/forge_raw_materials_silver.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/silver/forge_raw_materials_silver.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/silver"}],"result":{"item":"unifyworks:silver_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/c_dusts_stainless_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/c_dusts_stainless_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/stainless_steel"}],"result":{"item":"unifyworks:stainless_steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/c_ingots_stainless_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/c_ingots_stainless_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/stainless_steel"}],"result":{"item":"unifyworks:stainless_steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/c_nuggets_stainless_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/c_nuggets_stainless_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/stainless_steel"}],"result":{"item":"unifyworks:stainless_steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/c_raw_materials_stainless_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/c_raw_materials_stainless_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/stainless_steel"}],"result":{"item":"unifyworks:stainless_steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/forge_dusts_stainless_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/forge_dusts_stainless_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/stainless_steel"}],"result":{"item":"unifyworks:stainless_steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/forge_ingots_stainless_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/forge_ingots_stainless_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/stainless_steel"}],"result":{"item":"unifyworks:stainless_steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/forge_nuggets_stainless_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/forge_nuggets_stainless_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/stainless_steel"}],"result":{"item":"unifyworks:stainless_steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/forge_raw_materials_stainless_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/stainless_steel/forge_raw_materials_stainless_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/stainless_steel"}],"result":{"item":"unifyworks:stainless_steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/c_dusts_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/c_dusts_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/steel"}],"result":{"item":"unifyworks:steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/c_ingots_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/c_ingots_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/steel"}],"result":{"item":"unifyworks:steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/c_nuggets_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/c_nuggets_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/steel"}],"result":{"item":"unifyworks:steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/c_raw_materials_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/c_raw_materials_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/steel"}],"result":{"item":"unifyworks:steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/forge_dusts_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/forge_dusts_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/steel"}],"result":{"item":"unifyworks:steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/forge_ingots_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/forge_ingots_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/steel"}],"result":{"item":"unifyworks:steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/forge_nuggets_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/forge_nuggets_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/steel"}],"result":{"item":"unifyworks:steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/forge_raw_materials_steel.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/steel/forge_raw_materials_steel.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/steel"}],"result":{"item":"unifyworks:steel_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/c_dusts_sulfur.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/c_dusts_sulfur.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/sulfur"}],"result":{"item":"unifyworks:sulfur_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/c_gems_sulfur.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/c_gems_sulfur.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:gems/sulfur"}],"result":{"item":"unifyworks:sulfur_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/c_nuggets_sulfur.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/c_nuggets_sulfur.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/sulfur"}],"result":{"item":"unifyworks:sulfur_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/forge_dusts_sulfur.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/forge_dusts_sulfur.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/sulfur"}],"result":{"item":"unifyworks:sulfur_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/forge_gems_sulfur.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/forge_gems_sulfur.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:gems/sulfur"}],"result":{"item":"unifyworks:sulfur_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/forge_nuggets_sulfur.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/sulfur/forge_nuggets_sulfur.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/sulfur"}],"result":{"item":"unifyworks:sulfur_gem"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/c_dusts_tin.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/c_dusts_tin.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/tin"}],"result":{"item":"unifyworks:tin_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/c_ingots_tin.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/c_ingots_tin.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/tin"}],"result":{"item":"unifyworks:tin_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/c_nuggets_tin.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/c_nuggets_tin.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/tin"}],"result":{"item":"unifyworks:tin_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/c_raw_materials_tin.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/c_raw_materials_tin.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/tin"}],"result":{"item":"unifyworks:tin_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/forge_dusts_tin.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/forge_dusts_tin.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/tin"}],"result":{"item":"unifyworks:tin_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/forge_ingots_tin.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/forge_ingots_tin.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/tin"}],"result":{"item":"unifyworks:tin_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/forge_nuggets_tin.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/forge_nuggets_tin.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/tin"}],"result":{"item":"unifyworks:tin_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/forge_raw_materials_tin.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tin/forge_raw_materials_tin.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/tin"}],"result":{"item":"unifyworks:tin_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/c_dusts_titanium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/c_dusts_titanium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/titanium"}],"result":{"item":"unifyworks:titanium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/c_ingots_titanium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/c_ingots_titanium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/titanium"}],"result":{"item":"unifyworks:titanium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/c_nuggets_titanium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/c_nuggets_titanium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/titanium"}],"result":{"item":"unifyworks:titanium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/c_raw_materials_titanium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/c_raw_materials_titanium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/titanium"}],"result":{"item":"unifyworks:titanium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/forge_dusts_titanium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/forge_dusts_titanium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/titanium"}],"result":{"item":"unifyworks:titanium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/forge_ingots_titanium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/forge_ingots_titanium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/titanium"}],"result":{"item":"unifyworks:titanium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/forge_nuggets_titanium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/forge_nuggets_titanium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/titanium"}],"result":{"item":"unifyworks:titanium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/forge_raw_materials_titanium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/titanium/forge_raw_materials_titanium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/titanium"}],"result":{"item":"unifyworks:titanium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/c_dusts_tungsten.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/c_dusts_tungsten.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/tungsten"}],"result":{"item":"unifyworks:tungsten_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/c_ingots_tungsten.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/c_ingots_tungsten.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/tungsten"}],"result":{"item":"unifyworks:tungsten_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/c_nuggets_tungsten.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/c_nuggets_tungsten.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/tungsten"}],"result":{"item":"unifyworks:tungsten_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/c_raw_materials_tungsten.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/c_raw_materials_tungsten.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/tungsten"}],"result":{"item":"unifyworks:tungsten_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/forge_dusts_tungsten.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/forge_dusts_tungsten.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/tungsten"}],"result":{"item":"unifyworks:tungsten_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/forge_ingots_tungsten.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/forge_ingots_tungsten.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/tungsten"}],"result":{"item":"unifyworks:tungsten_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/forge_nuggets_tungsten.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/forge_nuggets_tungsten.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/tungsten"}],"result":{"item":"unifyworks:tungsten_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/forge_raw_materials_tungsten.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/tungsten/forge_raw_materials_tungsten.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/tungsten"}],"result":{"item":"unifyworks:tungsten_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/c_dusts_uranium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/c_dusts_uranium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/uranium"}],"result":{"item":"unifyworks:uranium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/c_ingots_uranium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/c_ingots_uranium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/uranium"}],"result":{"item":"unifyworks:uranium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/c_nuggets_uranium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/c_nuggets_uranium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/uranium"}],"result":{"item":"unifyworks:uranium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/c_raw_materials_uranium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/c_raw_materials_uranium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/uranium"}],"result":{"item":"unifyworks:uranium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/forge_dusts_uranium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/forge_dusts_uranium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/uranium"}],"result":{"item":"unifyworks:uranium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/forge_ingots_uranium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/forge_ingots_uranium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/uranium"}],"result":{"item":"unifyworks:uranium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/forge_nuggets_uranium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/forge_nuggets_uranium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/uranium"}],"result":{"item":"unifyworks:uranium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/forge_raw_materials_uranium.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/uranium/forge_raw_materials_uranium.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/uranium"}],"result":{"item":"unifyworks:uranium_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/c_dusts_zinc.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/c_dusts_zinc.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:dusts/zinc"}],"result":{"item":"unifyworks:zinc_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/c_ingots_zinc.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/c_ingots_zinc.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:ingots/zinc"}],"result":{"item":"unifyworks:zinc_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/c_nuggets_zinc.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/c_nuggets_zinc.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:nuggets/zinc"}],"result":{"item":"unifyworks:zinc_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/c_raw_materials_zinc.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/c_raw_materials_zinc.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"c:raw_materials/zinc"}],"result":{"item":"unifyworks:zinc_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/forge_dusts_zinc.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/forge_dusts_zinc.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:dusts/zinc"}],"result":{"item":"unifyworks:zinc_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/forge_ingots_zinc.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/forge_ingots_zinc.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:ingots/zinc"}],"result":{"item":"unifyworks:zinc_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/forge_nuggets_zinc.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/forge_nuggets_zinc.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:nuggets/zinc"}],"result":{"item":"unifyworks:zinc_ingot"},"category":"misc"}

--- a/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/forge_raw_materials_zinc.json
+++ b/src/main/resources/data/unifyworks/recipes/unify_from_tag/zinc/forge_raw_materials_zinc.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"tag":"forge:raw_materials/zinc"}],"result":{"item":"unifyworks:zinc_ingot"},"category":"misc"}


### PR DESCRIPTION
## Summary
- document the pack's unification strategy and KubeJS usage helpers
- add shapeless recipes that convert tagged ingots, gems, raw chunks, dusts, and nuggets into the UnifyWorks canonical outputs
- provide a KubeJS startup script example for removing materials, replacing inputs with tags, and forcing canonical drops

## Testing
- not run (data-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd88e7bcc08327b1289f3c37132127