### PR TITLE
Add runtime canonicalization and raw material tags

### DIFF
--- a/DOCS/runtime_canonicalization.md
+++ b/DOCS/runtime_canonicalization.md
@@ -1,0 +1,14 @@
+Runtime canonicalization
+=======================
+- Hooks ItemCraftedEvent and ItemSmeltedEvent.
+- If the produced item belongs to a unification tag family, replace it with the UnifyWorks canonical item.
+- Avoids mutating third-party JSON. Works with recipes that use hardcoded inputs.
+
+Limits
+------
+- Heuristic material extraction from item IDs is best-effort. Future work: drive via materials.json index of tag keys per material.
+- Does not intercept outputs from custom machines. Pack authors can add KubeJS conversions for those.
+
+Timeout policy
+--------------
+If execution is going to time out, push current changes via a PR and note in the summary how far you made it in these tasks.

--- a/src/main/java/com/unifyworks/datagen/UWDataGenBootstrap.java
+++ b/src/main/java/com/unifyworks/datagen/UWDataGenBootstrap.java
@@ -15,6 +15,7 @@ public final class UWDataGenBootstrap {
         var blockTags = new UWBlockTagsProvider(packOutput, lookupProvider, existingFileHelper);
         generator.addProvider(event.includeServer(), blockTags);
         generator.addProvider(event.includeServer(), new UWItemTagsProvider(packOutput, lookupProvider, blockTags, existingFileHelper));
+        generator.addProvider(event.includeServer(), new UWRawTagsProvider(packOutput, lookupProvider, blockTags, existingFileHelper));
         generator.addProvider(event.includeServer(), new UWRecipeProvider(packOutput, lookupProvider));
         generator.addProvider(event.includeClient(), new UWBlockStateProvider(packOutput, existingFileHelper));
         generator.addProvider(event.includeClient(), new UWItemModelProvider(packOutput, existingFileHelper));

--- a/src/main/java/com/unifyworks/datagen/UWRawTagsProvider.java
+++ b/src/main/java/com/unifyworks/datagen/UWRawTagsProvider.java
@@ -1,0 +1,34 @@
+package com.unifyworks.datagen;
+
+import com.unifyworks.UnifyWorks;
+import com.unifyworks.data.MaterialsIndex;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.ItemTagsProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import net.neoforged.neoforge.common.data.BlockTagsProvider;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+
+import java.util.concurrent.CompletableFuture;
+
+public class UWRawTagsProvider extends ItemTagsProvider {
+    public UWRawTagsProvider(PackOutput out, CompletableFuture<HolderLookup.Provider> lookup, BlockTagsProvider blockTags, ExistingFileHelper helper) {
+        super(out, lookup, blockTags.contentsGetter(), UnifyWorks.MODID, helper);
+    }
+
+    private static TagKey<Item> tag(String ns, String path) {
+        return TagKey.create(net.minecraft.core.registries.Registries.ITEM, new ResourceLocation(ns, path));
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider provider) {
+        var snap = MaterialsIndex.loadBootstrap();
+        for (var m : snap.metals) {
+            var rawId = new ResourceLocation(UnifyWorks.MODID, "raw_" + m);
+            this.tag(tag("forge", "raw_materials/" + m)).addOptional(rawId);
+            this.tag(tag("c", "raw_materials/" + m)).addOptional(rawId);
+        }
+    }
+}

--- a/src/main/java/com/unifyworks/unify/CanonicalSelector.java
+++ b/src/main/java/com/unifyworks/unify/CanonicalSelector.java
@@ -1,0 +1,30 @@
+package com.unifyworks.unify;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
+
+import java.util.Optional;
+
+/** Picks a canonical item from a tag, preferring UnifyWorks namespace. */
+public final class CanonicalSelector {
+    private CanonicalSelector() {}
+
+    public static Optional<Item> pick(TagKey<Item> tag) {
+        var registry = BuiltInRegistries.ITEM;
+        var holders = registry.getTag(tag).orElse(null);
+        if (holders == null) return Optional.empty();
+
+        Item fallback = null;
+        for (Holder<Item> h : holders) {
+            Item it = h.value();
+            ResourceLocation id = registry.getKey(it);
+            if (id == null) continue;
+            if (id.getNamespace().equals("unifyworks")) return Optional.of(it);
+            if (fallback == null) fallback = it;
+        }
+        return Optional.ofNullable(fallback);
+    }
+}

--- a/src/main/java/com/unifyworks/unify/RuntimeCanonicalization.java
+++ b/src/main/java/com/unifyworks/unify/RuntimeCanonicalization.java
@@ -1,0 +1,78 @@
+package com.unifyworks.unify;
+
+import com.unifyworks.UnifyWorks;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+
+import java.util.List;
+
+@Mod.EventBusSubscriber(modid = UnifyWorks.MODID)
+public final class RuntimeCanonicalization {
+    private record FamilySpec(String tagPath, String prefix, String suffix, List<String> namespaces) {
+        FamilySpec(String tagPath, String prefix, String suffix, String... namespaces) {
+            this(tagPath, prefix, suffix, List.of(namespaces));
+        }
+
+        String extractMaterial(String itemPath) {
+            if (suffix != null && itemPath.endsWith(suffix)) {
+                return itemPath.substring(0, itemPath.length() - suffix.length());
+            }
+            if (prefix != null && itemPath.startsWith(prefix)) {
+                return itemPath.substring(prefix.length());
+            }
+            return null;
+        }
+    }
+
+    private static final List<FamilySpec> FAMILIES = List.of(
+            new FamilySpec("ingots", null, "_ingot", "forge", "c"),
+            new FamilySpec("gems", null, "_gem", "forge", "c"),
+            new FamilySpec("raw_materials", "raw_", null, "forge", "c"),
+            new FamilySpec("dusts", null, "_dust", "forge", "c"),
+            new FamilySpec("nuggets", null, "_nugget", "forge", "c")
+    );
+
+    private RuntimeCanonicalization() {}
+
+    @SubscribeEvent
+    public static void onCrafted(PlayerEvent.ItemCraftedEvent evt) {
+        canonicalize(evt.getCrafting());
+    }
+
+    @SubscribeEvent
+    public static void onSmelted(PlayerEvent.ItemSmeltedEvent evt) {
+        canonicalize(evt.getSmelting());
+    }
+
+    private static void canonicalize(ItemStack stack) {
+        if (stack.isEmpty()) return;
+        var registry = BuiltInRegistries.ITEM;
+        var id = registry.getKey(stack.getItem());
+        if (id == null) return;
+        String itemPath = id.getPath();
+
+        for (FamilySpec spec : FAMILIES) {
+            String material = spec.extractMaterial(itemPath);
+            if (material == null || material.isEmpty()) continue;
+
+            for (String namespace : spec.namespaces()) {
+                ResourceLocation tagId = new ResourceLocation(namespace, spec.tagPath() + "/" + material);
+                TagKey<Item> tag = TagKey.create(Registries.ITEM, tagId);
+                var pick = CanonicalSelector.pick(tag);
+                if (pick.isPresent() && stack.getItem() != pick.get()) {
+                    int count = stack.getCount();
+                    stack.setItem(pick.get());
+                    stack.setCount(count);
+                    return;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement runtime canonicalization that swaps crafted and smelted outputs to the UnifyWorks canonical item for supported tag families
- add a raw material item tags provider so forge/c tag sets include UnifyWorks raw metal items at generation time
- document the runtime canonicalization flow and current limitations

## Testing
- `./gradlew --no-daemon --console=plain --stacktrace --version` *(fails: Gradle distribution download blocked by offline environment)*
- `scripts/gradle-offline.sh --version` *(fails: offline Gradle not bootstrapped in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9560952083279d58cd19adf8d80d