### PR TITLE
Add UnifyWorks creative tab and sanity advancements

### DIFF
--- a/src/main/java/com/unifyworks/UnifyWorks.java
+++ b/src/main/java/com/unifyworks/UnifyWorks.java
@@ -4,6 +4,7 @@ import com.unifyworks.data.MaterialsIndex;
 import com.unifyworks.datagen.UWDataGenBootstrap;
 import com.unifyworks.loot.LootHooks;
 import com.unifyworks.registry.UWBlocks;
+import com.unifyworks.registry.UWCreativeTab;
 import com.unifyworks.registry.UWItems;
 import com.unifyworks.registry.UWOres;
 import com.unifyworks.registry.UWOreItems;
@@ -26,6 +27,7 @@ public class UnifyWorks {
         UWBlocks.BLOCKS.register(modBus);
         UWOres.BLOCKS.register(modBus);
         UWOreItems.ITEMS.register(modBus);
+        UWCreativeTab.TABS.register(modBus);
         LootHooks.init(modBus);
 
         modBus.addListener(this::onCommonSetup);

--- a/src/main/java/com/unifyworks/registry/UWCreativeTab.java
+++ b/src/main/java/com/unifyworks/registry/UWCreativeTab.java
@@ -1,0 +1,33 @@
+package com.unifyworks.registry;
+
+import com.unifyworks.UnifyWorks;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.RegistryObject;
+
+public final class UWCreativeTab {
+    public static final DeferredRegister<CreativeModeTab> TABS =
+            DeferredRegister.create(Registries.CREATIVE_MODE_TAB, UnifyWorks.MODID);
+
+    public static final RegistryObject<CreativeModeTab> MAIN = TABS.register("main",
+            () -> CreativeModeTab.builder()
+                    .title(Component.translatable("itemGroup.unifyworks"))
+                    .icon(() -> UWItems.BASE_ITEMS.values().stream()
+                            .findFirst()
+                            .map(holder -> new ItemStack(holder.get()))
+                            .orElse(ItemStack.EMPTY))
+                    .displayItems((params, output) -> {
+                        UWItems.NUGGETS.values().forEach(holder -> output.accept(holder.get()));
+                        UWItems.BASE_ITEMS.values().forEach(holder -> output.accept(holder.get()));
+                        UWBlocks.STORAGE_BLOCKS.values().forEach(holder -> output.accept(holder.get()));
+                        UWOres.STONE.values().forEach(holder -> output.accept(holder.get()));
+                        UWOres.DEEPSLATE.values().forEach(holder -> output.accept(holder.get()));
+                        UWOres.NETHERRACK.values().forEach(holder -> output.accept(holder.get()));
+                    })
+                    .build());
+
+    private UWCreativeTab() {}
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/aluminum.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/aluminum.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:aluminum_ingot"
+    },
+    "title": {
+      "text": "Unified aluminum"
+    },
+    "description": {
+      "text": "Obtain the unified aluminum base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:aluminum_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/antimony.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/antimony.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:antimony_ingot"
+    },
+    "title": {
+      "text": "Unified antimony"
+    },
+    "description": {
+      "text": "Obtain the unified antimony base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:antimony_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/apatite.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/apatite.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:apatite_gem"
+    },
+    "title": {
+      "text": "Unified apatite"
+    },
+    "description": {
+      "text": "Obtain the unified apatite base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:apatite_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/bronze.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/bronze.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:bronze_ingot"
+    },
+    "title": {
+      "text": "Unified bronze"
+    },
+    "description": {
+      "text": "Obtain the unified bronze base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:bronze_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/chromium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/chromium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:chromium_ingot"
+    },
+    "title": {
+      "text": "Unified chromium"
+    },
+    "description": {
+      "text": "Obtain the unified chromium base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:chromium_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/constantan.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/constantan.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:constantan_ingot"
+    },
+    "title": {
+      "text": "Unified constantan"
+    },
+    "description": {
+      "text": "Obtain the unified constantan base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:constantan_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/copper.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/copper.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:copper_ingot"
+    },
+    "title": {
+      "text": "Unified copper"
+    },
+    "description": {
+      "text": "Obtain the unified copper base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:copper_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/diamond.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/diamond.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:diamond_gem"
+    },
+    "title": {
+      "text": "Unified diamond"
+    },
+    "description": {
+      "text": "Obtain the unified diamond base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:diamond_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/dimensional_shard.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/dimensional_shard.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:dimensional_shard_gem"
+    },
+    "title": {
+      "text": "Unified dimensional_shard"
+    },
+    "description": {
+      "text": "Obtain the unified dimensional_shard base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:dimensional_shard_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/electrum.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/electrum.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:electrum_ingot"
+    },
+    "title": {
+      "text": "Unified electrum"
+    },
+    "description": {
+      "text": "Obtain the unified electrum base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:electrum_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/emerald.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/emerald.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:emerald_gem"
+    },
+    "title": {
+      "text": "Unified emerald"
+    },
+    "description": {
+      "text": "Obtain the unified emerald base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:emerald_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/fluorite.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/fluorite.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:fluorite_gem"
+    },
+    "title": {
+      "text": "Unified fluorite"
+    },
+    "description": {
+      "text": "Obtain the unified fluorite base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:fluorite_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/gold.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/gold.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:gold_ingot"
+    },
+    "title": {
+      "text": "Unified gold"
+    },
+    "description": {
+      "text": "Obtain the unified gold base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:gold_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/graphite.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/graphite.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:graphite_gem"
+    },
+    "title": {
+      "text": "Unified graphite"
+    },
+    "description": {
+      "text": "Obtain the unified graphite base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:graphite_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/invar.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/invar.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:invar_ingot"
+    },
+    "title": {
+      "text": "Unified invar"
+    },
+    "description": {
+      "text": "Obtain the unified invar base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:invar_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/iridium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/iridium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:iridium_ingot"
+    },
+    "title": {
+      "text": "Unified iridium"
+    },
+    "description": {
+      "text": "Obtain the unified iridium base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:iridium_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/iron.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/iron.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:iron_ingot"
+    },
+    "title": {
+      "text": "Unified iron"
+    },
+    "description": {
+      "text": "Obtain the unified iron base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:iron_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/lapis_lazuli.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/lapis_lazuli.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:lapis_lazuli_gem"
+    },
+    "title": {
+      "text": "Unified lapis_lazuli"
+    },
+    "description": {
+      "text": "Obtain the unified lapis_lazuli base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:lapis_lazuli_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/lead.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/lead.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:lead_ingot"
+    },
+    "title": {
+      "text": "Unified lead"
+    },
+    "description": {
+      "text": "Obtain the unified lead base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:lead_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/lumium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/lumium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:lumium_ingot"
+    },
+    "title": {
+      "text": "Unified lumium"
+    },
+    "description": {
+      "text": "Obtain the unified lumium base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:lumium_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/monazite.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/monazite.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:monazite_gem"
+    },
+    "title": {
+      "text": "Unified monazite"
+    },
+    "description": {
+      "text": "Obtain the unified monazite base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:monazite_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/netherite.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/netherite.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:netherite_ingot"
+    },
+    "title": {
+      "text": "Unified netherite"
+    },
+    "description": {
+      "text": "Obtain the unified netherite base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:netherite_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/nickel.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/nickel.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:nickel_ingot"
+    },
+    "title": {
+      "text": "Unified nickel"
+    },
+    "description": {
+      "text": "Obtain the unified nickel base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:nickel_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/osmium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/osmium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:osmium_ingot"
+    },
+    "title": {
+      "text": "Unified osmium"
+    },
+    "description": {
+      "text": "Obtain the unified osmium base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:osmium_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/platinum.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/platinum.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:platinum_ingot"
+    },
+    "title": {
+      "text": "Unified platinum"
+    },
+    "description": {
+      "text": "Obtain the unified platinum base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:platinum_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/plutonium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/plutonium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:plutonium_ingot"
+    },
+    "title": {
+      "text": "Unified plutonium"
+    },
+    "description": {
+      "text": "Obtain the unified plutonium base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:plutonium_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/quartz.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/quartz.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:quartz_gem"
+    },
+    "title": {
+      "text": "Unified quartz"
+    },
+    "description": {
+      "text": "Obtain the unified quartz base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:quartz_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/redstone.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/redstone.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:redstone_gem"
+    },
+    "title": {
+      "text": "Unified redstone"
+    },
+    "description": {
+      "text": "Obtain the unified redstone base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:redstone_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/refined_glowstone.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/refined_glowstone.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:refined_glowstone_ingot"
+    },
+    "title": {
+      "text": "Unified refined_glowstone"
+    },
+    "description": {
+      "text": "Obtain the unified refined_glowstone base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:refined_glowstone_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/refined_obsidian.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/refined_obsidian.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:refined_obsidian_ingot"
+    },
+    "title": {
+      "text": "Unified refined_obsidian"
+    },
+    "description": {
+      "text": "Obtain the unified refined_obsidian base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:refined_obsidian_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/resonating_ore.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/resonating_ore.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:resonating_ore_gem"
+    },
+    "title": {
+      "text": "Unified resonating_ore"
+    },
+    "description": {
+      "text": "Obtain the unified resonating_ore base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:resonating_ore_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/ruby.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/ruby.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:ruby_gem"
+    },
+    "title": {
+      "text": "Unified ruby"
+    },
+    "description": {
+      "text": "Obtain the unified ruby base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:ruby_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/sapphire.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/sapphire.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:sapphire_gem"
+    },
+    "title": {
+      "text": "Unified sapphire"
+    },
+    "description": {
+      "text": "Obtain the unified sapphire base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:sapphire_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/silicon.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/silicon.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:silicon_gem"
+    },
+    "title": {
+      "text": "Unified silicon"
+    },
+    "description": {
+      "text": "Obtain the unified silicon base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:silicon_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/silver.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/silver.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:silver_ingot"
+    },
+    "title": {
+      "text": "Unified silver"
+    },
+    "description": {
+      "text": "Obtain the unified silver base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:silver_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/stainless_steel.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/stainless_steel.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:stainless_steel_ingot"
+    },
+    "title": {
+      "text": "Unified stainless_steel"
+    },
+    "description": {
+      "text": "Obtain the unified stainless_steel base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:stainless_steel_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/steel.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/steel.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:steel_ingot"
+    },
+    "title": {
+      "text": "Unified steel"
+    },
+    "description": {
+      "text": "Obtain the unified steel base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:steel_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/sulfur.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/sulfur.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:sulfur_gem"
+    },
+    "title": {
+      "text": "Unified sulfur"
+    },
+    "description": {
+      "text": "Obtain the unified sulfur base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:sulfur_gem"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/tin.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/tin.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:tin_ingot"
+    },
+    "title": {
+      "text": "Unified tin"
+    },
+    "description": {
+      "text": "Obtain the unified tin base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:tin_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/titanium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/titanium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:titanium_ingot"
+    },
+    "title": {
+      "text": "Unified titanium"
+    },
+    "description": {
+      "text": "Obtain the unified titanium base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:titanium_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/tungsten.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/tungsten.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:tungsten_ingot"
+    },
+    "title": {
+      "text": "Unified tungsten"
+    },
+    "description": {
+      "text": "Obtain the unified tungsten base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:tungsten_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/uranium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/uranium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:uranium_ingot"
+    },
+    "title": {
+      "text": "Unified uranium"
+    },
+    "description": {
+      "text": "Obtain the unified uranium base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:uranium_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_base/zinc.json
+++ b/src/main/resources/data/unifyworks/advancements/get_base/zinc.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:zinc_ingot"
+    },
+    "title": {
+      "text": "Unified zinc"
+    },
+    "description": {
+      "text": "Obtain the unified zinc base item"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_base": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:zinc_ingot"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/aluminum.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/aluminum.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:aluminum_block"
+    },
+    "title": {
+      "text": "Unified aluminum Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified aluminum storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:aluminum_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/antimony.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/antimony.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:antimony_block"
+    },
+    "title": {
+      "text": "Unified antimony Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified antimony storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:antimony_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/apatite.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/apatite.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:apatite_block"
+    },
+    "title": {
+      "text": "Unified apatite Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified apatite storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:apatite_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/bronze.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/bronze.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:bronze_block"
+    },
+    "title": {
+      "text": "Unified bronze Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified bronze storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:bronze_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/chromium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/chromium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:chromium_block"
+    },
+    "title": {
+      "text": "Unified chromium Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified chromium storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:chromium_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/constantan.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/constantan.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:constantan_block"
+    },
+    "title": {
+      "text": "Unified constantan Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified constantan storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:constantan_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/copper.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/copper.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:copper_block"
+    },
+    "title": {
+      "text": "Unified copper Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified copper storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:copper_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/diamond.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/diamond.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:diamond_block"
+    },
+    "title": {
+      "text": "Unified diamond Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified diamond storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:diamond_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/dimensional_shard.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/dimensional_shard.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:dimensional_shard_block"
+    },
+    "title": {
+      "text": "Unified dimensional_shard Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified dimensional_shard storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:dimensional_shard_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/electrum.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/electrum.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:electrum_block"
+    },
+    "title": {
+      "text": "Unified electrum Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified electrum storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:electrum_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/emerald.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/emerald.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:emerald_block"
+    },
+    "title": {
+      "text": "Unified emerald Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified emerald storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:emerald_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/fluorite.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/fluorite.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:fluorite_block"
+    },
+    "title": {
+      "text": "Unified fluorite Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified fluorite storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:fluorite_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/gold.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/gold.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:gold_block"
+    },
+    "title": {
+      "text": "Unified gold Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified gold storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:gold_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/graphite.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/graphite.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:graphite_block"
+    },
+    "title": {
+      "text": "Unified graphite Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified graphite storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:graphite_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/invar.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/invar.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:invar_block"
+    },
+    "title": {
+      "text": "Unified invar Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified invar storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:invar_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/iridium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/iridium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:iridium_block"
+    },
+    "title": {
+      "text": "Unified iridium Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified iridium storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:iridium_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/iron.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/iron.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:iron_block"
+    },
+    "title": {
+      "text": "Unified iron Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified iron storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:iron_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/lapis_lazuli.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/lapis_lazuli.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:lapis_lazuli_block"
+    },
+    "title": {
+      "text": "Unified lapis_lazuli Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified lapis_lazuli storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:lapis_lazuli_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/lead.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/lead.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:lead_block"
+    },
+    "title": {
+      "text": "Unified lead Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified lead storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:lead_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/lumium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/lumium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:lumium_block"
+    },
+    "title": {
+      "text": "Unified lumium Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified lumium storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:lumium_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/monazite.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/monazite.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:monazite_block"
+    },
+    "title": {
+      "text": "Unified monazite Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified monazite storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:monazite_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/netherite.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/netherite.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:netherite_block"
+    },
+    "title": {
+      "text": "Unified netherite Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified netherite storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:netherite_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/nickel.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/nickel.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:nickel_block"
+    },
+    "title": {
+      "text": "Unified nickel Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified nickel storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:nickel_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/osmium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/osmium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:osmium_block"
+    },
+    "title": {
+      "text": "Unified osmium Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified osmium storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:osmium_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/platinum.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/platinum.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:platinum_block"
+    },
+    "title": {
+      "text": "Unified platinum Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified platinum storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:platinum_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/plutonium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/plutonium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:plutonium_block"
+    },
+    "title": {
+      "text": "Unified plutonium Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified plutonium storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:plutonium_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/quartz.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/quartz.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:quartz_block"
+    },
+    "title": {
+      "text": "Unified quartz Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified quartz storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:quartz_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/redstone.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/redstone.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:redstone_block"
+    },
+    "title": {
+      "text": "Unified redstone Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified redstone storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:redstone_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/refined_glowstone.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/refined_glowstone.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:refined_glowstone_block"
+    },
+    "title": {
+      "text": "Unified refined_glowstone Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified refined_glowstone storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:refined_glowstone_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/refined_obsidian.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/refined_obsidian.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:refined_obsidian_block"
+    },
+    "title": {
+      "text": "Unified refined_obsidian Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified refined_obsidian storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:refined_obsidian_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/resonating_ore.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/resonating_ore.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:resonating_ore_block"
+    },
+    "title": {
+      "text": "Unified resonating_ore Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified resonating_ore storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:resonating_ore_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/ruby.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/ruby.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:ruby_block"
+    },
+    "title": {
+      "text": "Unified ruby Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified ruby storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:ruby_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/sapphire.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/sapphire.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:sapphire_block"
+    },
+    "title": {
+      "text": "Unified sapphire Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified sapphire storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:sapphire_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/silicon.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/silicon.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:silicon_block"
+    },
+    "title": {
+      "text": "Unified silicon Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified silicon storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:silicon_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/silver.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/silver.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:silver_block"
+    },
+    "title": {
+      "text": "Unified silver Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified silver storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:silver_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/stainless_steel.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/stainless_steel.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:stainless_steel_block"
+    },
+    "title": {
+      "text": "Unified stainless_steel Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified stainless_steel storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:stainless_steel_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/steel.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/steel.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:steel_block"
+    },
+    "title": {
+      "text": "Unified steel Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified steel storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:steel_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/sulfur.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/sulfur.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:sulfur_block"
+    },
+    "title": {
+      "text": "Unified sulfur Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified sulfur storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:sulfur_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/tin.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/tin.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:tin_block"
+    },
+    "title": {
+      "text": "Unified tin Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified tin storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:tin_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/titanium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/titanium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:titanium_block"
+    },
+    "title": {
+      "text": "Unified titanium Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified titanium storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:titanium_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/tungsten.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/tungsten.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:tungsten_block"
+    },
+    "title": {
+      "text": "Unified tungsten Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified tungsten storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:tungsten_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/uranium.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/uranium.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:uranium_block"
+    },
+    "title": {
+      "text": "Unified uranium Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified uranium storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:uranium_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/data/unifyworks/advancements/get_block/zinc.json
+++ b/src/main/resources/data/unifyworks/advancements/get_block/zinc.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "icon": {
+      "item": "unifyworks:zinc_block"
+    },
+    "title": {
+      "text": "Unified zinc Block"
+    },
+    "description": {
+      "text": "Craft or obtain the unified zinc storage block"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": false,
+    "hidden": false
+  },
+  "criteria": {
+    "has_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "unifyworks:zinc_block"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated UnifyWorks creative tab that displays nuggets, base items, storage blocks, and ores
- register the creative tab alongside existing item and block registries
- generate minimal advancements that unlock when obtaining each unified base item or storage block

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddb24be9148327a6f76f22cbcc0e83