### PR TITLE
Add config gating for materials and compression

### DIFF
--- a/DOCS/config.md
+++ b/DOCS/config.md
@@ -1,0 +1,16 @@
+Config gates
+============
+- `general.enableDropUnifier`: toggle the GLM for ore drops.
+- `compression.*`: master and per-family toggles for registering compressed items/blocks. `maxTier` caps tiers (1..9).
+- `filters.denyMaterials`: blacklist unified materials (metals or gems) by id.
+- `filters.denyStones`: blacklist stones by id.
+
+Behavior
+--------
+- Filters apply at registration time. Disabled materials are not registered, and their recipes/tags should be omitted by your static resource process.
+- `maxTier` limits both item and block compressed tiers.
+
+Pack guidance
+-------------
+- Use KubeJS or datapacks for fine-grained recipe removals. Use the config for coarse control over registries.
+- If going to time out in Codex, push current changes via a PR and note completed steps and TODOs in the summary.

--- a/src/main/java/com/unifyworks/UnifyWorks.java
+++ b/src/main/java/com/unifyworks/UnifyWorks.java
@@ -20,13 +20,16 @@ public class UnifyWorks {
 
         IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
 
-        var snap = MaterialsIndex.loadBootstrap();
+        MaterialsIndex.Snapshot snap = MaterialsIndex.loadBootstrap()
+                .filtered(UWConfig.denyMaterials(), UWConfig.denyStones());
         UWItems.ITEMS.register(modBus);
         UWBlocks.BLOCKS.register(modBus);
         UWOres.BLOCKS.register(modBus);
         UWOreItems.ITEMS.register(modBus);
-        UWCompressed.ITEMS.register(modBus);
-        UWCompressed.BLOCKS.register(modBus);
+        if (UWConfig.compressionEnabled()) {
+            UWCompressed.ITEMS.register(modBus);
+            UWCompressed.BLOCKS.register(modBus);
+        }
         UWCreativeTab.TABS.register(modBus);
         LootHooks.init(modBus);
 
@@ -34,7 +37,20 @@ public class UnifyWorks {
         UWBlocks.bootstrap(snap.metals, snap.gems);
         UWOres.bootstrap(snap);
         UWOreItems.bootstrap();
-        UWCompressed.bootstrap(snap, 9);
+        if (UWConfig.compressionEnabled()) {
+            MaterialsIndex.Snapshot compressionSnapshot = new MaterialsIndex.Snapshot();
+            if (UWConfig.compressionMetals()) {
+                compressionSnapshot.metals.addAll(snap.metals);
+            }
+            if (UWConfig.compressionGems()) {
+                compressionSnapshot.gems.addAll(snap.gems);
+            }
+            if (UWConfig.compressionStones()) {
+                compressionSnapshot.stones.addAll(snap.stones);
+            }
+
+            UWCompressed.bootstrap(compressionSnapshot, UWConfig.maxTier());
+        }
 
         modBus.addListener(this::onCommonSetup);
     }

--- a/src/main/java/com/unifyworks/config/UWConfig.java
+++ b/src/main/java/com/unifyworks/config/UWConfig.java
@@ -2,31 +2,95 @@ package com.unifyworks.config;
 
 import net.neoforged.neoforge.common.ModConfigSpec;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public final class UWConfig {
     public static final ModConfigSpec COMMON_SPEC;
-    public static final Common COMMON;
+
+    private static final ModConfigSpec.BooleanValue ENABLE_DROP_UNIFIER;
+    private static final ModConfigSpec.BooleanValue ENABLE_COMPRESSION;
+    private static final ModConfigSpec.BooleanValue ENABLE_COMPRESSION_METALS;
+    private static final ModConfigSpec.BooleanValue ENABLE_COMPRESSION_GEMS;
+    private static final ModConfigSpec.BooleanValue ENABLE_COMPRESSION_STONES;
+    private static final ModConfigSpec.IntValue MAX_COMPRESSION_TIER;
+    private static final ModConfigSpec.ConfigValue<List<? extends String>> DENY_MATERIALS;
+    private static final ModConfigSpec.ConfigValue<List<? extends String>> DENY_STONES;
 
     static {
         ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
-        COMMON = new Common(builder);
+
+        builder.push("general");
+        ENABLE_DROP_UNIFIER = builder
+                .comment("Enable the global loot modifier that unifies ore drops to the canonical raw chunk or gem.")
+                .define("enableDropUnifier", true);
+        builder.pop();
+
+        builder.push("compression");
+        ENABLE_COMPRESSION = builder.comment("Master toggle for all compression registrations.")
+                .define("enable", true);
+        ENABLE_COMPRESSION_METALS = builder.comment("Enable compressed metal items and blocks.")
+                .define("enableMetals", true);
+        ENABLE_COMPRESSION_GEMS = builder.comment("Enable compressed gem items and blocks.")
+                .define("enableGems", true);
+        ENABLE_COMPRESSION_STONES = builder.comment("Enable compressed stone blocks.")
+                .define("enableStones", true);
+        MAX_COMPRESSION_TIER = builder.comment("Maximum compression tier (1-9).")
+                .defineInRange("maxTier", 9, 1, 9);
+        builder.pop();
+
+        builder.push("filters");
+        DENY_MATERIALS = builder
+                .comment("Blacklist unified metals or gems by id. Entries here are excluded from registration.")
+                .defineList("denyMaterials", List.of(), o -> o instanceof String);
+        DENY_STONES = builder
+                .comment("Blacklist unified stones by id. Entries here are excluded from registration.")
+                .defineList("denyStones", List.of(), o -> o instanceof String);
+        builder.pop();
+
         COMMON_SPEC = builder.build();
     }
 
     private UWConfig() {}
 
-    public static final class Common {
-        private final ModConfigSpec.BooleanValue enableDropUnifier;
+    public static boolean dropUnifierEnabled() {
+        return ENABLE_DROP_UNIFIER.get();
+    }
 
-        private Common(ModConfigSpec.Builder builder) {
-            builder.push("general");
-            enableDropUnifier = builder
-                    .comment("Enable the global loot modifier that unifies ore drops to the canonical raw chunk or gem.")
-                    .define("enableDropUnifier", true);
-            builder.pop();
-        }
+    public static boolean compressionEnabled() {
+        return ENABLE_COMPRESSION.get();
+    }
 
-        public boolean dropUnifierEnabled() {
-            return enableDropUnifier.get();
-        }
+    public static boolean compressionMetals() {
+        return ENABLE_COMPRESSION_METALS.get();
+    }
+
+    public static boolean compressionGems() {
+        return ENABLE_COMPRESSION_GEMS.get();
+    }
+
+    public static boolean compressionStones() {
+        return ENABLE_COMPRESSION_STONES.get();
+    }
+
+    public static int maxTier() {
+        return MAX_COMPRESSION_TIER.get();
+    }
+
+    public static Set<String> denyMaterials() {
+        return DENY_MATERIALS.get().stream()
+                .map(String::valueOf)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toSet());
+    }
+
+    public static Set<String> denyStones() {
+        return DENY_STONES.get().stream()
+                .map(String::valueOf)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/unifyworks/data/MaterialsIndex.java
+++ b/src/main/java/com/unifyworks/data/MaterialsIndex.java
@@ -91,6 +91,59 @@ public class MaterialsIndex {
                 addOreEntry(ore);
             }
         }
+
+        public Snapshot filtered(Set<String> denyMaterials, Set<String> denyStones) {
+            Set<String> blockedMaterials = denyMaterials == null ? Set.of() : denyMaterials;
+            Set<String> blockedStones = denyStones == null ? Set.of() : denyStones;
+
+            Snapshot filtered = new Snapshot();
+
+            for (MaterialEntry entry : materials.values()) {
+                if (blockedMaterials.contains(entry.name())) continue;
+                if ("stone".equals(entry.kind()) && blockedStones.contains(entry.name())) continue;
+                filtered.addMaterial(entry);
+            }
+
+            for (AliasEntry alias : oreAliases) {
+                if (blockedMaterials.contains(alias.name())) continue;
+                String aliasTo = alias.aliasTo();
+                if (aliasTo != null) {
+                    String canonical = canonicalName(aliasTo);
+                    if (canonical != null && blockedMaterials.contains(canonical)) continue;
+                    if (blockedMaterials.contains(aliasTo)) continue;
+                }
+                filtered.addOreAlias(alias);
+            }
+
+            for (OreEntry ore : ores) {
+                if (blockedMaterials.contains(ore.name())) continue;
+                filtered.addOreEntry(ore);
+            }
+
+            for (String metal : metals) {
+                if (!blockedMaterials.contains(metal)) {
+                    addUnique(filtered.metals, metal);
+                }
+            }
+            for (String gem : gems) {
+                if (!blockedMaterials.contains(gem)) {
+                    addUnique(filtered.gems, gem);
+                }
+            }
+            for (String stone : stones) {
+                if (!blockedStones.contains(stone)) {
+                    addUnique(filtered.stones, stone);
+                }
+            }
+
+            return filtered;
+        }
+
+        public Set<String> allMaterials() {
+            Set<String> all = new LinkedHashSet<>(metals);
+            all.addAll(gems);
+            return Set.copyOf(all);
+        }
     }
 
     public record OreEntry(String name, boolean stone, boolean deepslate, boolean netherrack) {}

--- a/src/main/java/com/unifyworks/loot/UWDropUnifier.java
+++ b/src/main/java/com/unifyworks/loot/UWDropUnifier.java
@@ -28,7 +28,7 @@ public class UWDropUnifier extends LootModifier {
 
     @Override
     protected ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext ctx) {
-        if (!enabledFromData || !UWConfig.COMMON.dropUnifierEnabled()) {
+        if (!enabledFromData || !UWConfig.dropUnifierEnabled()) {
             return generatedLoot;
         }
 

--- a/src/main/resources/unifyworks-common.toml
+++ b/src/main/resources/unifyworks-common.toml
@@ -1,8 +1,15 @@
-# UnifyWorks compression configuration
-enableCompression = true
-enableBaseCompression = true      # ingots/gems -> compressed items
-enableBlockCompression = true     # storage blocks -> compressed blocks
-enableStoneCompression = true     # stone tags -> compressed blocks
-maxCompressionTier = 9
-enableReverseCompression = true
-enableDropUnifier = true          # global loot modifier for canonical ore drops
+[general]
+enableDropUnifier = true # global loot modifier for canonical ore drops
+
+[compression]
+enable = true
+enableMetals = true
+enableGems = true
+enableStones = true
+maxTier = 9
+
+[filters]
+# Unified materials to deny at bootstrap time (metals or gems)
+denyMaterials = []
+# Stones to deny at bootstrap time
+denyStones = []


### PR DESCRIPTION
## Summary
- expand the common config with compression toggles and deny lists for materials and stones
- filter the bootstrap material snapshot and guard registry bootstrap and compression registration against the config
- document the new options and refresh the default common config file

## Testing
- `./gradlew compileJava` *(fails: gradle wrapper cannot download dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dde2ad971c8327b0e01be9b920fbb8