### PR TITLE
Add diagnostics commands and configurable ore pruning

### DIFF
--- a/DOCS/diagnostics.md
+++ b/DOCS/diagnostics.md
@@ -1,0 +1,17 @@
+Diagnostics
+===========
+Commands:
+- `/unifyworks diag materials` — prints enabled metals/gems/stones after config filters, lists disabled entries, and shows the current compression tier limit.
+- `/unifyworks diag tags <material>` — resolves aliases, reports ore tag presence, and checks whether UnifyWorks ore blocks appear in each canonical tag.
+- `/unifyworks diag item` — inspects the item in the executing player's main hand, resolves its canonical family material, and shows tag/canonical item coverage.
+- `/unifyworks worldgen dump` — summarizes worldgen toggles (including pruning) and enumerates UnifyWorks placed features found in the registry.
+
+Worldgen pruning
+----------------
+- `pruneNonUnifyOres=true` keeps JSON biome modifiers that use the `unifyworks:conditional_remove_features` codec to remove `#forge:ores` from Overworld and Nether biomes when worldgen is enabled for that dimension.
+- Combined with `conditional_add_features`, this enforces “only UnifyWorks ore features” without deleting datapack files.
+- Set to false to keep external ore features.
+
+Timeout policy
+--------------
+If going to time out, push current changes via a PR and include a summary of what landed.

--- a/src/main/java/com/unifyworks/commands/UWCommands.java
+++ b/src/main/java/com/unifyworks/commands/UWCommands.java
@@ -1,45 +1,271 @@
 package com.unifyworks.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.unifyworks.UnifyWorks;
+import com.unifyworks.config.UWConfig;
+import com.unifyworks.config.UWWorldgenConfig;
+import com.unifyworks.data.MaterialsIndex;
+import com.unifyworks.data.UnifyDataReload;
+import com.unifyworks.unify.CanonicalFamilies;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 public final class UWCommands {
-    public static void register(RegisterCommandsEvent event) {
-        CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
-        dispatcher.register(Commands.literal("unifyworks").requires(stack -> stack.hasPermission(2))
+    private static final String PREFIX = "[UnifyWorks] ";
+    private static final int LIST_CHUNK = 10;
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("unifyworks").requires(s -> s.hasPermission(2))
                 .then(Commands.literal("worldgen")
-                        .then(Commands.literal("dump").executes(ctx -> dumpPlacedFeatures(ctx.getSource())))));
+                        .then(Commands.literal("dump").executes(ctx -> dumpWorldgen(ctx.getSource()))))
+                .then(Commands.literal("diag")
+                        .then(Commands.literal("materials").executes(ctx -> diagMaterials(ctx.getSource())))
+                        .then(Commands.literal("tags")
+                                .then(Commands.argument("material", StringArgumentType.word())
+                                        .executes(ctx -> diagTags(ctx.getSource(), StringArgumentType.getString(ctx, "material")))))
+                        .then(Commands.literal("item")
+                                .executes(ctx -> diagItem(ctx.getSource(), ctx.getSource().getPlayerOrException())))));
     }
 
-    private static int dumpPlacedFeatures(CommandSourceStack source) {
-        var registry = source.getServer().registryAccess().registryOrThrow(Registries.PLACED_FEATURE);
-        List<ResourceLocation> ids = registry.registryKeySet().stream()
-                .map(key -> key.location())
-                .filter(loc -> loc.getNamespace().equals(UnifyWorks.MODID))
-                .sorted(Comparator.comparing(ResourceLocation::toString))
-                .toList();
+    private static int diagMaterials(CommandSourceStack src) {
+        MaterialsIndex.Snapshot snapshot = UnifyDataReload.snapshot();
+        Set<String> denyMaterials = UWConfig.denyMaterials();
+        Set<String> denyStones = UWConfig.denyStones();
+        MaterialsIndex.Snapshot enabled = snapshot.filtered(denyMaterials, denyStones);
 
-        if (ids.isEmpty()) {
-            UnifyWorks.LOGGER.info("[UnifyWorks] No placed features registered under namespace {}.", UnifyWorks.MODID);
-            source.sendSuccess(() -> Component.literal("[UnifyWorks] No placed features registered."), false);
+        List<String> metals = new ArrayList<>(enabled.metals);
+        metals.sort(String::compareTo);
+        List<String> gems = new ArrayList<>(enabled.gems);
+        gems.sort(String::compareTo);
+        List<String> stones = new ArrayList<>(enabled.stones);
+        stones.sort(String::compareTo);
+
+        Set<String> disabledMaterials = new TreeSet<>(snapshot.allMaterials());
+        disabledMaterials.removeAll(enabled.allMaterials());
+        disabledMaterials.addAll(denyMaterials);
+        List<String> disabledMaterialList = new ArrayList<>(disabledMaterials);
+
+        Set<String> allStones = new TreeSet<>(snapshot.stones);
+        allStones.removeAll(enabled.stones);
+        allStones.addAll(denyStones);
+        List<String> disabledStones = new ArrayList<>(allStones);
+
+        int maxTier = UWConfig.compressionEnabled() ? UWConfig.maxTier() : 0;
+        sendPrefixed(src, String.format(Locale.ROOT,
+                "Materials: metals=%d gems=%d stones=%d maxCompressionTier=%d",
+                metals.size(), gems.size(), stones.size(), maxTier));
+        sendList(src, "Enabled metals", metals);
+        sendList(src, "Enabled gems", gems);
+        sendList(src, "Enabled stones", stones);
+        sendList(src, "Disabled materials", disabledMaterialList);
+        sendList(src, "Disabled stones", disabledStones);
+        return 1;
+    }
+
+    private static int diagTags(CommandSourceStack src, String materialInput) {
+        String query = materialInput.toLowerCase(Locale.ROOT);
+        MaterialsIndex.Snapshot snapshot = UnifyDataReload.snapshot();
+        MaterialsIndex.MaterialEntry material = snapshot.find(query);
+        if (material == null) {
+            sendPrefixed(src, "Unknown material: " + query);
             return 0;
         }
 
-        UnifyWorks.LOGGER.info("[UnifyWorks] Dumping {} placed features:", ids.size());
-        ids.forEach(id -> UnifyWorks.LOGGER.info(" - {}", id));
-        source.sendSuccess(() -> Component.literal("[UnifyWorks] Logged " + ids.size() + " placed features."), false);
-        return ids.size();
+        String canonicalName = material.name();
+        boolean isAlias = !Objects.equals(canonicalName, query);
+        if (isAlias) {
+            sendPrefixed(src, String.format(Locale.ROOT, "Alias '%s' resolved to canonical material '%s'.", query, canonicalName));
+        } else {
+            sendPrefixed(src, "Material: " + canonicalName);
+        }
+        sendPrefixed(src, String.format(Locale.ROOT, "unify=%s generateOre=%s", material.unify(), material.generateOre()));
+
+        Set<String> denyMaterials = UWConfig.denyMaterials();
+        if (denyMaterials.contains(canonicalName)) {
+            sendPrefixed(src, "Warning: material is denied via config and will not register ores.");
+        }
+
+        MaterialsIndex.AliasEntry aliasEntry = null;
+        if (isAlias) {
+            aliasEntry = snapshot.oreAliases().stream()
+                    .filter(a -> a.name().equals(query))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        Map<ResourceLocation, List<String>> tagSources = new LinkedHashMap<>();
+        material.oreTags().forEach(tag -> tagSources.computeIfAbsent(tag, k -> new ArrayList<>()).add("canonical"));
+        if (aliasEntry != null) {
+            aliasEntry.oreTags().forEach(tag -> tagSources.computeIfAbsent(tag, k -> new ArrayList<>()).add("alias"));
+        }
+
+        if (tagSources.isEmpty()) {
+            sendPrefixed(src, "No ore tags recorded for this material.");
+        }
+
+        MaterialsIndex.OreEntry oreEntry = snapshot.ores.stream()
+                .filter(o -> o.name().equals(canonicalName))
+                .findFirst()
+                .orElse(null);
+        Map<String, ResourceLocation> expectedBlocks = new LinkedHashMap<>();
+        if (oreEntry != null) {
+            if (oreEntry.stone()) {
+                expectedBlocks.put("stone", new ResourceLocation(UnifyWorks.MODID, canonicalName + "_ore"));
+            }
+            if (oreEntry.deepslate()) {
+                expectedBlocks.put("deepslate", new ResourceLocation(UnifyWorks.MODID, "deepslate_" + canonicalName + "_ore"));
+            }
+            if (oreEntry.netherrack()) {
+                expectedBlocks.put("netherrack", new ResourceLocation(UnifyWorks.MODID, "netherrack_" + canonicalName + "_ore"));
+            }
+        }
+
+        Registry<Block> blockRegistry = src.getLevel().registryAccess().registryOrThrow(Registries.BLOCK);
+        for (Map.Entry<ResourceLocation, List<String>> entry : tagSources.entrySet()) {
+            ResourceLocation tagId = entry.getKey();
+            TagKey<Block> tagKey = TagKey.create(Registries.BLOCK, tagId);
+            var holdersOpt = blockRegistry.getTag(tagKey);
+            boolean present = holdersOpt.isPresent();
+            int entryCount = 0;
+            Map<String, Boolean> variantHits = new LinkedHashMap<>();
+            expectedBlocks.forEach((variant, id) -> variantHits.put(variant, false));
+            if (present) {
+                for (var holder : holdersOpt.get()) {
+                    entryCount++;
+                    ResourceLocation holderId = blockRegistry.getKey(holder.value());
+                    if (holderId == null) continue;
+                    for (Map.Entry<String, ResourceLocation> variant : expectedBlocks.entrySet()) {
+                        if (variant.getValue().equals(holderId)) {
+                            variantHits.put(variant.getKey(), true);
+                        }
+                    }
+                }
+            }
+
+            StringBuilder line = new StringBuilder();
+            line.append("Tag ").append(tagId).append(": present=").append(present);
+            line.append(" entries=").append(entryCount);
+            if (!entry.getValue().isEmpty()) {
+                line.append(" source=").append(String.join("+", entry.getValue()));
+            }
+            if (!variantHits.isEmpty()) {
+                String variantSummary = variantHits.entrySet().stream()
+                        .map(e -> e.getKey() + "=" + (e.getValue() ? "✔" : "✘"))
+                        .collect(Collectors.joining(", "));
+                line.append(" variants=").append(variantSummary);
+            }
+            sendPrefixed(src, line.toString());
+        }
+
+        if (oreEntry == null) {
+            sendPrefixed(src, "No UnifyWorks ore variants are registered for this material.");
+        }
+
+        return 1;
     }
 
-    private UWCommands() {
+    private static int diagItem(CommandSourceStack src, ServerPlayer player) {
+        ItemStack held = player.getMainHandItem();
+        if (held.isEmpty()) {
+            sendPrefixed(src, "Main hand is empty.");
+            return 0;
+        }
+
+        ResourceLocation heldId = BuiltInRegistries.ITEM.getKey(held.getItem());
+        sendPrefixed(src, String.format(Locale.ROOT, "Held %s x%d", heldId, held.getCount()));
+
+        Optional<CanonicalFamilies.FamilyDiagnostics> diagnostics = CanonicalFamilies.diagnose(held.getItem());
+        if (diagnostics.isEmpty()) {
+            sendPrefixed(src, "No canonical family heuristic matched this item.");
+            return 1;
+        }
+
+        CanonicalFamilies.FamilyDiagnostics diag = diagnostics.get();
+        sendPrefixed(src, String.format(Locale.ROOT, "Family=%s material=%s", diag.family().key(), diag.material()));
+
+        Item canonicalDrop = UnifyDataReload.resolveDrop(diag.material());
+        if (canonicalDrop != null) {
+            ResourceLocation dropId = BuiltInRegistries.ITEM.getKey(canonicalDrop);
+            sendPrefixed(src, "Canonical drop item=" + dropId);
+        }
+
+        for (CanonicalFamilies.TagCheck tag : diag.tags()) {
+            StringBuilder line = new StringBuilder();
+            line.append("Tag ").append(tag.tagId()).append(": present=").append(tag.present());
+            line.append(" entries=").append(tag.entryCount());
+            line.append(" containsHeld=").append(tag.containsHeld());
+            if (tag.hasCanonical()) {
+                line.append(" canonical=").append(tag.canonicalId());
+                line.append(" matchesHeld=").append(tag.canonicalMatches(held.getItem()));
+            } else {
+                line.append(" canonical=<missing>");
+            }
+            sendPrefixed(src, line.toString());
+        }
+
+        return 1;
     }
+
+    private static int dumpWorldgen(CommandSourceStack src) {
+        sendPrefixed(src, String.format(Locale.ROOT,
+                "Worldgen enabled=%s overworld=%s nether=%s end=%s prune=%s sizePct=%d countPct=%d",
+                UWWorldgenConfig.enabled(), UWWorldgenConfig.overworld(), UWWorldgenConfig.nether(),
+                UWWorldgenConfig.end(), UWWorldgenConfig.prune(), UWWorldgenConfig.sizePct(),
+                UWWorldgenConfig.countPct()));
+
+        Registry<PlacedFeature> placedRegistry = src.getLevel().registryAccess().registryOrThrow(Registries.PLACED_FEATURE);
+        List<String> unifyFeatures = placedRegistry.entrySet().stream()
+                .map(Map.Entry::getKey)
+                .map(ResourceKey::location)
+                .filter(loc -> loc.getNamespace().equals(UnifyWorks.MODID))
+                .map(ResourceLocation::toString)
+                .sorted(Comparator.naturalOrder())
+                .toList();
+        sendList(src, "Placed features (" + unifyFeatures.size() + ")", unifyFeatures);
+        return 1;
+    }
+
+    private static void sendPrefixed(CommandSourceStack src, String message) {
+        src.sendSuccess(() -> Component.literal(PREFIX + message), false);
+    }
+
+    private static void sendList(CommandSourceStack src, String label, List<String> values) {
+        if (values == null || values.isEmpty()) {
+            sendPrefixed(src, label + ": (none)");
+            return;
+        }
+        for (int i = 0; i < values.size(); i += LIST_CHUNK) {
+            int end = Math.min(values.size(), i + LIST_CHUNK);
+            String joined = String.join(", ", values.subList(i, end));
+            String prefix = i == 0 ? label + ": " : "  ";
+            sendPrefixed(src, prefix + joined);
+        }
+    }
+
+    private UWCommands() {}
 }

--- a/src/main/java/com/unifyworks/config/UWWorldgenConfig.java
+++ b/src/main/java/com/unifyworks/config/UWWorldgenConfig.java
@@ -10,6 +10,7 @@ public final class UWWorldgenConfig {
     private static final ModConfigSpec.BooleanValue ENABLE_END_ORES;
     private static final ModConfigSpec.IntValue SIZE_MULTIPLIER_PCT;
     private static final ModConfigSpec.IntValue COUNT_MULTIPLIER_PCT;
+    private static final ModConfigSpec.BooleanValue PRUNE_NON_UNIFY_ORES;
 
     static {
         ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
@@ -23,6 +24,8 @@ public final class UWWorldgenConfig {
                 .defineInRange("sizeMultiplierPct", 100, 10, 400);
         COUNT_MULTIPLIER_PCT = builder.comment("Global vein count multiplier in percent (applied at placement time).")
                 .defineInRange("countMultiplierPct", 100, 10, 400);
+        PRUNE_NON_UNIFY_ORES = builder.comment("Remove non-Unify ore features from biomes using removal modifiers.")
+                .define("pruneNonUnifyOres", true);
         builder.pop();
 
         SPEC = builder.build();
@@ -52,5 +55,9 @@ public final class UWWorldgenConfig {
 
     public static int countPct() {
         return COUNT_MULTIPLIER_PCT.get();
+    }
+
+    public static boolean prune() {
+        return PRUNE_NON_UNIFY_ORES.get();
     }
 }

--- a/src/main/java/com/unifyworks/unify/CanonicalFamilies.java
+++ b/src/main/java/com/unifyworks/unify/CanonicalFamilies.java
@@ -1,0 +1,108 @@
+package com.unifyworks.unify;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+public final class CanonicalFamilies {
+    public record Family(String key, String tagPath, String prefix, String suffix, List<String> namespaces) {
+        public Family(String key, String tagPath, String prefix, String suffix, String... namespaces) {
+            this(key, tagPath, prefix, suffix, List.of(namespaces));
+        }
+
+        public String extractMaterial(ResourceLocation itemId) {
+            if (itemId == null) return null;
+            String path = itemId.getPath();
+            if (prefix != null && !prefix.isEmpty()) {
+                if (!path.startsWith(prefix)) return null;
+                path = path.substring(prefix.length());
+            }
+            if (suffix != null && !suffix.isEmpty()) {
+                if (!path.endsWith(suffix)) return null;
+                path = path.substring(0, path.length() - suffix.length());
+            }
+            return path.isEmpty() ? null : path;
+        }
+    }
+
+    public record TagCheck(ResourceLocation tagId, boolean present, int entryCount, boolean containsHeld,
+                           Item canonicalItem, ResourceLocation canonicalId) {
+        public boolean hasCanonical() {
+            return canonicalItem != null;
+        }
+
+        public boolean canonicalMatches(Item item) {
+            return canonicalItem != null && canonicalItem == item;
+        }
+    }
+
+    public record FamilyDiagnostics(Family family, String material, ResourceLocation itemId, List<TagCheck> tags) {
+        public Optional<TagCheck> firstPresentTag() {
+            return tags.stream().filter(TagCheck::present).findFirst();
+        }
+
+        public Optional<TagCheck> tagContainingHeld() {
+            return tags.stream().filter(TagCheck::containsHeld).findFirst();
+        }
+    }
+
+    private static final List<Family> FAMILIES = List.of(
+            new Family("ingot", "ingots", null, "_ingot", "forge", "c"),
+            new Family("gem", "gems", null, "_gem", "forge", "c"),
+            new Family("raw", "raw_materials", "raw_", null, "forge", "c"),
+            new Family("dust", "dusts", null, "_dust", "forge", "c"),
+            new Family("nugget", "nuggets", null, "_nugget", "forge", "c"),
+            new Family("deepslate_ore", "ores", "deepslate_", "_ore", "forge", "c"),
+            new Family("nether_ore", "ores", "netherrack_", "_ore", "forge", "c"),
+            new Family("ore", "ores", null, "_ore", "forge", "c")
+    );
+
+    private CanonicalFamilies() {}
+
+    public static List<Family> all() {
+        return FAMILIES;
+    }
+
+    public static Optional<FamilyDiagnostics> diagnose(Item item) {
+        if (item == null) return Optional.empty();
+        ResourceLocation itemId = BuiltInRegistries.ITEM.getKey(item);
+        if (itemId == null) return Optional.empty();
+
+        for (Family family : FAMILIES) {
+            String material = family.extractMaterial(itemId);
+            if (material == null || material.isEmpty()) continue;
+
+            List<TagCheck> tags = new ArrayList<>();
+            for (String namespace : family.namespaces()) {
+                ResourceLocation tagId = new ResourceLocation(namespace.toLowerCase(Locale.ROOT),
+                        family.tagPath() + "/" + material);
+                TagKey<Item> tag = TagKey.create(Registries.ITEM, tagId);
+                var holdersOpt = BuiltInRegistries.ITEM.getTag(tag);
+                boolean present = holdersOpt.isPresent();
+                boolean containsHeld = false;
+                int entryCount = 0;
+                if (present) {
+                    for (Holder<Item> holder : holdersOpt.get()) {
+                        entryCount++;
+                        if (holder.value() == item) {
+                            containsHeld = true;
+                        }
+                    }
+                }
+                Item canonicalItem = CanonicalSelector.pick(tag).orElse(null);
+                ResourceLocation canonicalId = canonicalItem == null ? null : BuiltInRegistries.ITEM.getKey(canonicalItem);
+                tags.add(new TagCheck(tagId, present, entryCount, containsHeld, canonicalItem, canonicalId));
+            }
+            return Optional.of(new FamilyDiagnostics(family, material, itemId, List.copyOf(tags)));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/unifyworks/unify/RuntimeCanonicalization.java
+++ b/src/main/java/com/unifyworks/unify/RuntimeCanonicalization.java
@@ -1,44 +1,14 @@
 package com.unifyworks.unify;
 
 import com.unifyworks.UnifyWorks;
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.TagKey;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
-
-import java.util.List;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 
 @Mod.EventBusSubscriber(modid = UnifyWorks.MODID)
 public final class RuntimeCanonicalization {
-    private record FamilySpec(String tagPath, String prefix, String suffix, List<String> namespaces) {
-        FamilySpec(String tagPath, String prefix, String suffix, String... namespaces) {
-            this(tagPath, prefix, suffix, List.of(namespaces));
-        }
-
-        String extractMaterial(String itemPath) {
-            if (suffix != null && itemPath.endsWith(suffix)) {
-                return itemPath.substring(0, itemPath.length() - suffix.length());
-            }
-            if (prefix != null && itemPath.startsWith(prefix)) {
-                return itemPath.substring(prefix.length());
-            }
-            return null;
-        }
-    }
-
-    private static final List<FamilySpec> FAMILIES = List.of(
-            new FamilySpec("ingots", null, "_ingot", "forge", "c"),
-            new FamilySpec("gems", null, "_gem", "forge", "c"),
-            new FamilySpec("raw_materials", "raw_", null, "forge", "c"),
-            new FamilySpec("dusts", null, "_dust", "forge", "c"),
-            new FamilySpec("nuggets", null, "_nugget", "forge", "c")
-    );
-
     private RuntimeCanonicalization() {}
 
     @SubscribeEvent
@@ -53,26 +23,19 @@ public final class RuntimeCanonicalization {
 
     private static void canonicalize(ItemStack stack) {
         if (stack.isEmpty()) return;
-        var registry = BuiltInRegistries.ITEM;
-        var id = registry.getKey(stack.getItem());
-        if (id == null) return;
-        String itemPath = id.getPath();
+        var diagnostics = CanonicalFamilies.diagnose(stack.getItem());
+        if (diagnostics.isEmpty()) return;
 
-        for (FamilySpec spec : FAMILIES) {
-            String material = spec.extractMaterial(itemPath);
-            if (material == null || material.isEmpty()) continue;
-
-            for (String namespace : spec.namespaces()) {
-                ResourceLocation tagId = new ResourceLocation(namespace, spec.tagPath() + "/" + material);
-                TagKey<Item> tag = TagKey.create(Registries.ITEM, tagId);
-                var pick = CanonicalSelector.pick(tag);
-                if (pick.isPresent() && stack.getItem() != pick.get()) {
-                    int count = stack.getCount();
-                    stack.setItem(pick.get());
-                    stack.setCount(count);
-                    return;
-                }
-            }
+        Item held = stack.getItem();
+        for (CanonicalFamilies.TagCheck tag : diagnostics.get().tags()) {
+            if (!tag.present()) continue;
+            if (!tag.containsHeld()) continue;
+            Item canonical = tag.canonicalItem();
+            if (canonical == null || canonical == held) continue;
+            int count = stack.getCount();
+            stack.setItem(canonical);
+            stack.setCount(count);
+            return;
         }
     }
 }

--- a/src/main/java/com/unifyworks/worldgen/ConditionalRemoveFeatures.java
+++ b/src/main/java/com/unifyworks/worldgen/ConditionalRemoveFeatures.java
@@ -1,0 +1,46 @@
+package com.unifyworks.worldgen;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.unifyworks.config.UWWorldgenConfig;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.neoforged.neoforge.common.world.BiomeModifier;
+import net.neoforged.neoforge.common.world.ModifiableBiomeInfo;
+
+public record ConditionalRemoveFeatures(HolderSet<Biome> biomes,
+                                        HolderSet<PlacedFeature> features,
+                                        GenerationStep.Decoration step,
+                                        ConditionalAddFeatures.Target target) implements BiomeModifier {
+    public static final Codec<ConditionalRemoveFeatures> CODEC = RecordCodecBuilder.create(inst -> inst.group(
+            Biome.LIST_CODEC.fieldOf("biomes").forGetter(ConditionalRemoveFeatures::biomes),
+            PlacedFeature.LIST_CODEC.fieldOf("features").forGetter(ConditionalRemoveFeatures::features),
+            GenerationStep.Decoration.CODEC.fieldOf("step").forGetter(ConditionalRemoveFeatures::step),
+            ConditionalAddFeatures.Target.CODEC.optionalFieldOf("target", ConditionalAddFeatures.Target.ANY)
+                    .forGetter(ConditionalRemoveFeatures::target)
+    ).apply(inst, ConditionalRemoveFeatures::new));
+
+    @Override
+    public void modify(Holder<Biome> biome, Phase phase, ModifiableBiomeInfo.BiomeInfo.Builder builder) {
+        if (phase != Phase.REMOVE) return;
+        if (!biomes.contains(biome)) return;
+        if (!UWWorldgenConfig.enabled()) return;
+        if (!UWWorldgenConfig.prune()) return;
+        boolean allow = switch (target) {
+            case OVERWORLD -> UWWorldgenConfig.overworld();
+            case NETHER -> UWWorldgenConfig.nether();
+            case END -> UWWorldgenConfig.end();
+            case ANY -> true;
+        };
+        if (!allow) return;
+        builder.getGenerationSettings().getFeatures(step).removeIf(features::contains);
+    }
+
+    @Override
+    public Codec<? extends BiomeModifier> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/com/unifyworks/worldgen/UWBiomeModifiers.java
+++ b/src/main/java/com/unifyworks/worldgen/UWBiomeModifiers.java
@@ -13,6 +13,8 @@ public final class UWBiomeModifiers {
 
     public static final RegistryObject<Codec<? extends BiomeModifier>> CONDITIONAL_ADD =
             SERIALIZERS.register("conditional_add_features", () -> ConditionalAddFeatures.CODEC);
+    public static final RegistryObject<Codec<? extends BiomeModifier>> CONDITIONAL_REMOVE =
+            SERIALIZERS.register("conditional_remove_features", () -> ConditionalRemoveFeatures.CODEC);
 
     private UWBiomeModifiers() {}
 }

--- a/src/main/resources/data/unifyworks/forge/biome_modifier/remove_other_ores_overworld.json
+++ b/src/main/resources/data/unifyworks/forge/biome_modifier/remove_other_ores_overworld.json
@@ -1,7 +1,7 @@
 {
   "type": "unifyworks:conditional_remove_features",
-  "biomes": "#minecraft:is_nether",
+  "biomes": "#minecraft:is_overworld",
   "features": ["#forge:ores"],
   "step": "underground_ores",
-  "target": "nether"
+  "target": "overworld"
 }

--- a/src/main/resources/unifyworks-worldgen-common.toml
+++ b/src/main/resources/unifyworks-worldgen-common.toml
@@ -5,3 +5,4 @@ enableNetherOres = true
 enableEndOres = false
 sizeMultiplierPct = 100
 countMultiplierPct = 100
+pruneNonUnifyOres = true


### PR DESCRIPTION
## Summary
- add detailed /unifyworks diag commands for materials, tag coverage, held items, and worldgen reporting
- introduce canonical family diagnostics shared with runtime canonicalization logic
- gate non-Unify ore removal via a conditional biome modifier controlled by the pruneNonUnifyOres config toggle and document the workflow

## Testing
- `./gradlew check` *(fails: network unreachable while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68de83cbc4c483278423d71dc8e7343b