### PR TITLE
feat: add canonical recipe API and serializers

### DIFF
--- a/DOCS/canonical_recipes.md
+++ b/DOCS/canonical_recipes.md
@@ -1,0 +1,43 @@
+Canonical recipe serializers
+============================
+UnifyWorks exposes canonical crafting recipe serializers that automatically swap outputs to the mod's unified items.
+
+Serializers
+-----------
+- `unifyworks:canonical_shaped` — drop-in replacement for the vanilla shaped serializer.
+- `unifyworks:canonical_shapeless` — drop-in replacement for the vanilla shapeless serializer.
+
+Each serializer reads the same JSON payload as the vanilla equivalent. On craft and in the recipe book preview, results are
+replaced with the canonical item from the relevant tag family when available.
+
+Example
+-------
+```json
+{
+  "type": "unifyworks:canonical_shaped",
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "tag": "forge:ingots/copper"
+    }
+  },
+  "result": {
+    "item": "some_mod:copper_plate"
+  }
+}
+```
+
+At runtime the recipe output is automatically replaced with `unifyworks:copper_ingot` when the copper ingot family is available.
+
+Datagen toggle
+--------------
+Pass `-Dunifyworks.datagen.canonicalSerializers=true` when running data generation to emit UnifyWorks' own conversions with the
+canonical serializers instead of vanilla recipes.
+
+API helpers
+-----------
+Use `CanonicalAPI` to resolve canonical metadata for items at runtime. The helper supports querying canonical material ids,
+canonical item ids, and replacing stacks with their unified form.

--- a/src/main/java/com/unifyworks/UnifyWorks.java
+++ b/src/main/java/com/unifyworks/UnifyWorks.java
@@ -6,6 +6,7 @@ import com.unifyworks.config.UWConfig;
 import com.unifyworks.config.UWWorldgenConfig;
 import com.unifyworks.data.MaterialsIndex;
 import com.unifyworks.loot.LootHooks;
+import com.unifyworks.recipes.UWRecipes;
 import com.unifyworks.registry.*;
 import com.unifyworks.worldgen.UWBiomeModifiers;
 import net.neoforged.bus.api.IEventBus;
@@ -39,6 +40,7 @@ public class UnifyWorks {
             UWCompressed.BLOCKS.register(modBus);
         }
         UWCreativeTab.TABS.register(modBus);
+        UWRecipes.SERIALIZERS.register(modBus);
         LootHooks.init(modBus);
         UWBiomeModifiers.SERIALIZERS.register(modBus);
         NeoForge.EVENT_BUS.addListener(UWCommands::register);

--- a/src/main/java/com/unifyworks/api/CanonicalAPI.java
+++ b/src/main/java/com/unifyworks/api/CanonicalAPI.java
@@ -1,0 +1,172 @@
+package com.unifyworks.api;
+
+import com.unifyworks.data.MaterialsIndex;
+import com.unifyworks.unify.CanonicalFamilies;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Lightweight helpers that expose UnifyWorks' canonical material resolution for other mods and scripts.
+ */
+public final class CanonicalAPI {
+    private CanonicalAPI() {
+    }
+
+    private static MaterialsIndex.Snapshot bootstrap() {
+        return Holder.INSTANCE;
+    }
+
+    private static final class Holder {
+        private static final MaterialsIndex.Snapshot INSTANCE = MaterialsIndex.loadBootstrap();
+
+        private Holder() {
+        }
+    }
+
+    /**
+     * Represents a canonical material match for a given item or stack.
+     */
+    public record CanonicalMatch(CanonicalFamilies.Family family,
+                                 String materialId,
+                                 String canonicalMaterialId,
+                                 Item canonicalItem,
+                                 ResourceLocation canonicalItemId) {
+        public boolean hasCanonicalItem() {
+            return canonicalItem != null && canonicalItemId != null;
+        }
+
+        public ItemStack createStack(int count) {
+            if (!hasCanonicalItem()) {
+                return ItemStack.EMPTY;
+            }
+            return new ItemStack(canonicalItem, count);
+        }
+    }
+
+    /**
+     * Resolves canonical information for the given stack.
+     */
+    public static Optional<CanonicalMatch> resolve(ItemStack stack) {
+        if (stack == null || stack.isEmpty()) {
+            return Optional.empty();
+        }
+        return resolve(stack.getItem());
+    }
+
+    /**
+     * Resolves canonical information for the given item.
+     */
+    public static Optional<CanonicalMatch> resolve(Item item) {
+        if (item == null) {
+            return Optional.empty();
+        }
+        var diagnostics = CanonicalFamilies.diagnose(item);
+        if (diagnostics.isEmpty()) {
+            return Optional.empty();
+        }
+
+        MaterialsIndex.Snapshot snapshot = bootstrap();
+        var diag = diagnostics.get();
+        String material = diag.material();
+        String canonicalMaterial = snapshot.canonicalName(material);
+        if (canonicalMaterial == null) {
+            canonicalMaterial = material;
+        }
+
+        for (var tag : diag.tags()) {
+            if (!tag.present() || !tag.hasCanonical()) {
+                continue;
+            }
+            Item canonical = tag.canonicalItem();
+            ResourceLocation canonicalId = tag.canonicalId();
+            if (canonical == null || canonicalId == null) {
+                continue;
+            }
+            return Optional.of(new CanonicalMatch(diag.family(), material, canonicalMaterial, canonical, canonicalId));
+        }
+
+        return Optional.of(new CanonicalMatch(diag.family(), material, canonicalMaterial, null, null));
+    }
+
+    /**
+     * Returns the canonical material id for the given stack if it belongs to a known family.
+     */
+    public static Optional<String> canonicalMaterial(ItemStack stack) {
+        return resolve(stack).map(CanonicalMatch::canonicalMaterialId);
+    }
+
+    /**
+     * Returns the canonical item id for the given stack if one exists.
+     */
+    public static Optional<ResourceLocation> canonicalItemId(ItemStack stack) {
+        return resolve(stack).map(CanonicalMatch::canonicalItemId);
+    }
+
+    /**
+     * Returns a canonical replacement for the provided stack. If no canonical item exists the original stack is returned.
+     * The returned stack is always a new copy and the original stack is never modified.
+     */
+    public static ItemStack canonicalize(ItemStack stack) {
+        if (stack == null) {
+            return ItemStack.EMPTY;
+        }
+        if (stack.isEmpty()) {
+            return stack.copy();
+        }
+        var match = resolve(stack);
+        if (match.isEmpty()) {
+            return stack.copy();
+        }
+        CanonicalMatch canonical = match.get();
+        if (!canonical.hasCanonicalItem()) {
+            return stack.copy();
+        }
+        Item item = stack.getItem();
+        if (item == canonical.canonicalItem()) {
+            return stack.copy();
+        }
+        ItemStack replacement = canonical.createStack(stack.getCount());
+        return replacement.isEmpty() ? stack.copy() : replacement;
+    }
+
+    /**
+     * Tests whether the provided stack already matches the canonical item for its family.
+     */
+    public static boolean isCanonical(ItemStack stack) {
+        if (stack == null || stack.isEmpty()) {
+            return false;
+        }
+        var match = resolve(stack);
+        if (match.isEmpty()) {
+            return false;
+        }
+        CanonicalMatch canonical = match.get();
+        if (!canonical.hasCanonicalItem()) {
+            return false;
+        }
+        ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+        return Objects.equals(id, canonical.canonicalItemId());
+    }
+
+    /**
+     * Helper that resolves the canonical preview stack for recipe book displays.
+     */
+    public static ItemStack preview(ItemStack stack) {
+        if (stack == null) {
+            return ItemStack.EMPTY;
+        }
+        if (stack.isEmpty()) {
+            return stack.copy();
+        }
+        ItemStack resolved = canonicalize(stack);
+        if (!resolved.isEmpty()) {
+            return resolved;
+        }
+        return stack.copy();
+    }
+}

--- a/src/main/java/com/unifyworks/commands/UWCommands.java
+++ b/src/main/java/com/unifyworks/commands/UWCommands.java
@@ -3,6 +3,7 @@ package com.unifyworks.commands;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.unifyworks.UnifyWorks;
+import com.unifyworks.api.CanonicalAPI;
 import com.unifyworks.config.UWConfig;
 import com.unifyworks.config.UWWorldgenConfig;
 import com.unifyworks.data.MaterialsIndex;
@@ -207,6 +208,18 @@ public final class UWCommands {
 
         CanonicalFamilies.FamilyDiagnostics diag = diagnostics.get();
         sendPrefixed(src, String.format(Locale.ROOT, "Family=%s material=%s", diag.family().key(), diag.material()));
+
+        CanonicalAPI.resolve(held).ifPresent(match -> {
+            if (match.canonicalMaterialId() != null && !Objects.equals(match.canonicalMaterialId(), match.materialId())) {
+                sendPrefixed(src, "Canonical material=" + match.canonicalMaterialId());
+            }
+            if (match.hasCanonicalItem()) {
+                boolean matchesHeld = match.canonicalItem() == held.getItem();
+                sendPrefixed(src, String.format(Locale.ROOT, "Canonical item=%s matchesHeld=%s", match.canonicalItemId(), matchesHeld));
+            } else {
+                sendPrefixed(src, "Canonical item=<unresolved>");
+            }
+        });
 
         Item canonicalDrop = UnifyDataReload.resolveDrop(diag.material());
         if (canonicalDrop != null) {

--- a/src/main/java/com/unifyworks/datagen/UWDataGenBootstrap.java
+++ b/src/main/java/com/unifyworks/datagen/UWDataGenBootstrap.java
@@ -11,12 +11,13 @@ public final class UWDataGenBootstrap {
         var packOutput = generator.getPackOutput();
         var existingFileHelper = event.getExistingFileHelper();
         var lookupProvider = event.getLookupProvider();
+        boolean canonicalSerializers = Boolean.getBoolean("unifyworks.datagen.canonicalSerializers");
 
         var blockTags = new UWBlockTagsProvider(packOutput, lookupProvider, existingFileHelper);
         generator.addProvider(event.includeServer(), blockTags);
         generator.addProvider(event.includeServer(), new UWItemTagsProvider(packOutput, lookupProvider, blockTags, existingFileHelper));
         generator.addProvider(event.includeServer(), new UWRawTagsProvider(packOutput, lookupProvider, blockTags, existingFileHelper));
-        generator.addProvider(event.includeServer(), new UWRecipeProvider(packOutput, lookupProvider));
+        generator.addProvider(event.includeServer(), new UWRecipeProvider(packOutput, lookupProvider, canonicalSerializers));
         generator.addProvider(event.includeClient(), new UWBlockStateProvider(packOutput, existingFileHelper));
         generator.addProvider(event.includeClient(), new UWItemModelProvider(packOutput, existingFileHelper));
     }

--- a/src/main/java/com/unifyworks/datagen/UWRecipeProvider.java
+++ b/src/main/java/com/unifyworks/datagen/UWRecipeProvider.java
@@ -4,6 +4,11 @@ import com.unifyworks.UnifyWorks;
 import com.unifyworks.data.MaterialsIndex;
 import com.unifyworks.registry.UWBlocks;
 import com.unifyworks.registry.UWItems;
+import com.unifyworks.recipes.CanonicalShapedRecipe;
+import com.unifyworks.recipes.CanonicalShapelessRecipe;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.recipes.RecipeCategory;
 import net.minecraft.data.recipes.RecipeOutput;
@@ -11,19 +16,32 @@ import net.minecraft.data.recipes.RecipeProvider;
 import net.minecraft.data.recipes.ShapedRecipeBuilder;
 import net.minecraft.data.recipes.ShapelessRecipeBuilder;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import net.minecraft.world.item.crafting.ShapelessRecipe;
+import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.block.Block;
 
 import java.util.concurrent.CompletableFuture;
 
 /** Generates 9 nuggets <-> 1 base, and 9 base <-> 1 storage block. */
 public class UWRecipeProvider extends RecipeProvider {
+    private final boolean canonicalSerializers;
+
     public UWRecipeProvider(PackOutput output, CompletableFuture<net.minecraft.core.HolderLookup.Provider> registries) {
+        this(output, registries, false);
+    }
+
+    public UWRecipeProvider(PackOutput output,
+                            CompletableFuture<net.minecraft.core.HolderLookup.Provider> registries,
+                            boolean canonicalSerializers) {
         super(output, registries);
+        this.canonicalSerializers = canonicalSerializers;
     }
 
     @Override
     protected void buildRecipes(RecipeOutput out) {
         var snap = MaterialsIndex.loadBootstrap();
+        RecipeOutput target = canonicalSerializers ? canonicalize(out) : out;
 
         for (var m : snap.metals) {
             var nuggetEntry = UWItems.NUGGETS.get(m);
@@ -39,22 +57,22 @@ public class UWRecipeProvider extends RecipeProvider {
             ShapedRecipeBuilder.shaped(RecipeCategory.MISC, ingot)
                     .define('#', nugget).pattern("###").pattern("###").pattern("###")
                     .unlockedBy("has_nugget", has(nugget))
-                    .save(out, UnifyWorks.MODID + ":ingot_from_nuggets/" + m);
+                    .save(target, UnifyWorks.MODID + ":ingot_from_nuggets/" + m);
 
             ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, nugget, 9)
                     .requires(ingot)
                     .unlockedBy("has_ingot", has(ingot))
-                    .save(out, UnifyWorks.MODID + ":nuggets_from_ingot/" + m);
+                    .save(target, UnifyWorks.MODID + ":nuggets_from_ingot/" + m);
 
             ShapedRecipeBuilder.shaped(RecipeCategory.BUILDING_BLOCKS, block)
                     .define('#', ingot).pattern("###").pattern("###").pattern("###")
                     .unlockedBy("has_ingot", has(ingot))
-                    .save(out, UnifyWorks.MODID + ":block_from_ingots/" + m);
+                    .save(target, UnifyWorks.MODID + ":block_from_ingots/" + m);
 
             ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, ingot, 9)
                     .requires(block)
                     .unlockedBy("has_block", has(block))
-                    .save(out, UnifyWorks.MODID + ":ingots_from_block/" + m);
+                    .save(target, UnifyWorks.MODID + ":ingots_from_block/" + m);
         }
 
         for (var g : snap.gems) {
@@ -71,22 +89,44 @@ public class UWRecipeProvider extends RecipeProvider {
             ShapedRecipeBuilder.shaped(RecipeCategory.MISC, gem)
                     .define('#', nugget).pattern("###").pattern("###").pattern("###")
                     .unlockedBy("has_nugget", has(nugget))
-                    .save(out, UnifyWorks.MODID + ":gem_from_nuggets/" + g);
+                    .save(target, UnifyWorks.MODID + ":gem_from_nuggets/" + g);
 
             ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, nugget, 9)
                     .requires(gem)
                     .unlockedBy("has_gem", has(gem))
-                    .save(out, UnifyWorks.MODID + ":nuggets_from_gem/" + g);
+                    .save(target, UnifyWorks.MODID + ":nuggets_from_gem/" + g);
 
             ShapedRecipeBuilder.shaped(RecipeCategory.BUILDING_BLOCKS, block)
                     .define('#', gem).pattern("###").pattern("###").pattern("###")
                     .unlockedBy("has_gem", has(gem))
-                    .save(out, UnifyWorks.MODID + ":block_from_gems/" + g);
+                    .save(target, UnifyWorks.MODID + ":block_from_gems/" + g);
 
             ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, gem, 9)
                     .requires(block)
                     .unlockedBy("has_block", has(block))
-                    .save(out, UnifyWorks.MODID + ":gems_from_block/" + g);
+                    .save(target, UnifyWorks.MODID + ":gems_from_block/" + g);
         }
+    }
+
+    private RecipeOutput canonicalize(RecipeOutput delegate) {
+        return new RecipeOutput() {
+            @Override
+            public void accept(ResourceLocation id, Recipe<?> recipe, AdvancementHolder advancement) {
+                if (recipe instanceof ShapedRecipe shaped) {
+                    delegate.accept(id, new CanonicalShapedRecipe(shaped), advancement);
+                    return;
+                }
+                if (recipe instanceof ShapelessRecipe shapeless) {
+                    delegate.accept(id, new CanonicalShapelessRecipe(shapeless), advancement);
+                    return;
+                }
+                delegate.accept(id, recipe, advancement);
+            }
+
+            @Override
+            public Advancement.Builder advancement() {
+                return delegate.advancement();
+            }
+        };
     }
 }

--- a/src/main/java/com/unifyworks/recipes/CanonicalShapedRecipe.java
+++ b/src/main/java/com/unifyworks/recipes/CanonicalShapedRecipe.java
@@ -1,0 +1,127 @@
+package com.unifyworks.recipes;
+
+import com.unifyworks.api.CanonicalAPI;
+import com.google.gson.JsonObject;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.NonNullList;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingInput;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import net.minecraft.world.level.Level;
+
+/**
+ * Wrapper around the vanilla shaped recipe that canonicalizes its outputs when crafted or previewed.
+ */
+public final class CanonicalShapedRecipe implements CraftingRecipe {
+    private final ShapedRecipe delegate;
+
+    public CanonicalShapedRecipe(ShapedRecipe delegate) {
+        this.delegate = delegate;
+    }
+
+    public ShapedRecipe delegate() {
+        return delegate;
+    }
+
+    @Override
+    public boolean matches(CraftingInput input, Level level) {
+        return delegate.matches(input, level);
+    }
+
+    @Override
+    public ItemStack assemble(CraftingInput input, HolderLookup.Provider provider) {
+        ItemStack assembled = delegate.assemble(input, provider);
+        return CanonicalAPI.canonicalize(assembled);
+    }
+
+    @Override
+    public ItemStack getResultItem(HolderLookup.Provider provider) {
+        return CanonicalAPI.preview(delegate.getResultItem(provider));
+    }
+
+    @Override
+    public boolean canCraftInDimensions(int width, int height) {
+        return delegate.canCraftInDimensions(width, height);
+    }
+
+    @Override
+    public NonNullList<ItemStack> getRemainingItems(CraftingInput input) {
+        return delegate.getRemainingItems(input);
+    }
+
+    @Override
+    public NonNullList<Ingredient> getIngredients() {
+        return delegate.getIngredients();
+    }
+
+    @Override
+    public ItemStack getToastSymbol() {
+        return delegate.getToastSymbol();
+    }
+
+    @Override
+    public ResourceLocation getId() {
+        return delegate.getId();
+    }
+
+    @Override
+    public String getGroup() {
+        return delegate.getGroup();
+    }
+
+    @Override
+    public CraftingBookCategory category() {
+        return delegate.category();
+    }
+
+    @Override
+    public boolean showNotification() {
+        return delegate.showNotification();
+    }
+
+    @Override
+    public boolean isIncomplete() {
+        return delegate.isIncomplete();
+    }
+
+    @Override
+    public RecipeSerializer<?> getSerializer() {
+        return UWRecipes.CANONICAL_SHAPED.get();
+    }
+
+    @Override
+    public RecipeType<?> getType() {
+        return delegate.getType();
+    }
+
+    @Override
+    public boolean isSpecial() {
+        return delegate.isSpecial();
+    }
+
+    public static final class Serializer implements RecipeSerializer<CanonicalShapedRecipe> {
+        @Override
+        public CanonicalShapedRecipe fromJson(ResourceLocation id, JsonObject json) {
+            ShapedRecipe vanilla = RecipeSerializer.SHAPED_RECIPE.fromJson(id, json);
+            return new CanonicalShapedRecipe(vanilla);
+        }
+
+        @Override
+        public CanonicalShapedRecipe fromNetwork(ResourceLocation id, FriendlyByteBuf buffer) {
+            ShapedRecipe vanilla = RecipeSerializer.SHAPED_RECIPE.fromNetwork(id, buffer);
+            return new CanonicalShapedRecipe(vanilla);
+        }
+
+        @Override
+        public void toNetwork(FriendlyByteBuf buffer, CanonicalShapedRecipe recipe) {
+            RecipeSerializer.SHAPED_RECIPE.toNetwork(buffer, recipe.delegate());
+        }
+    }
+}

--- a/src/main/java/com/unifyworks/recipes/CanonicalShapelessRecipe.java
+++ b/src/main/java/com/unifyworks/recipes/CanonicalShapelessRecipe.java
@@ -1,0 +1,127 @@
+package com.unifyworks.recipes;
+
+import com.google.gson.JsonObject;
+import com.unifyworks.api.CanonicalAPI;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.NonNullList;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingInput;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.item.crafting.ShapelessRecipe;
+import net.minecraft.world.level.Level;
+
+/**
+ * Wrapper around the vanilla shapeless recipe that canonicalizes its outputs.
+ */
+public final class CanonicalShapelessRecipe implements CraftingRecipe {
+    private final ShapelessRecipe delegate;
+
+    public CanonicalShapelessRecipe(ShapelessRecipe delegate) {
+        this.delegate = delegate;
+    }
+
+    public ShapelessRecipe delegate() {
+        return delegate;
+    }
+
+    @Override
+    public boolean matches(CraftingInput input, Level level) {
+        return delegate.matches(input, level);
+    }
+
+    @Override
+    public ItemStack assemble(CraftingInput input, HolderLookup.Provider provider) {
+        ItemStack assembled = delegate.assemble(input, provider);
+        return CanonicalAPI.canonicalize(assembled);
+    }
+
+    @Override
+    public ItemStack getResultItem(HolderLookup.Provider provider) {
+        return CanonicalAPI.preview(delegate.getResultItem(provider));
+    }
+
+    @Override
+    public boolean canCraftInDimensions(int width, int height) {
+        return delegate.canCraftInDimensions(width, height);
+    }
+
+    @Override
+    public NonNullList<ItemStack> getRemainingItems(CraftingInput input) {
+        return delegate.getRemainingItems(input);
+    }
+
+    @Override
+    public NonNullList<Ingredient> getIngredients() {
+        return delegate.getIngredients();
+    }
+
+    @Override
+    public ItemStack getToastSymbol() {
+        return delegate.getToastSymbol();
+    }
+
+    @Override
+    public ResourceLocation getId() {
+        return delegate.getId();
+    }
+
+    @Override
+    public String getGroup() {
+        return delegate.getGroup();
+    }
+
+    @Override
+    public CraftingBookCategory category() {
+        return delegate.category();
+    }
+
+    @Override
+    public boolean showNotification() {
+        return delegate.showNotification();
+    }
+
+    @Override
+    public boolean isIncomplete() {
+        return delegate.isIncomplete();
+    }
+
+    @Override
+    public RecipeSerializer<?> getSerializer() {
+        return UWRecipes.CANONICAL_SHAPELESS.get();
+    }
+
+    @Override
+    public RecipeType<?> getType() {
+        return delegate.getType();
+    }
+
+    @Override
+    public boolean isSpecial() {
+        return delegate.isSpecial();
+    }
+
+    public static final class Serializer implements RecipeSerializer<CanonicalShapelessRecipe> {
+        @Override
+        public CanonicalShapelessRecipe fromJson(ResourceLocation id, JsonObject json) {
+            ShapelessRecipe vanilla = RecipeSerializer.SHAPELESS_RECIPE.fromJson(id, json);
+            return new CanonicalShapelessRecipe(vanilla);
+        }
+
+        @Override
+        public CanonicalShapelessRecipe fromNetwork(ResourceLocation id, FriendlyByteBuf buffer) {
+            ShapelessRecipe vanilla = RecipeSerializer.SHAPELESS_RECIPE.fromNetwork(id, buffer);
+            return new CanonicalShapelessRecipe(vanilla);
+        }
+
+        @Override
+        public void toNetwork(FriendlyByteBuf buffer, CanonicalShapelessRecipe recipe) {
+            RecipeSerializer.SHAPELESS_RECIPE.toNetwork(buffer, recipe.delegate());
+        }
+    }
+}

--- a/src/main/java/com/unifyworks/recipes/UWRecipes.java
+++ b/src/main/java/com/unifyworks/recipes/UWRecipes.java
@@ -1,0 +1,24 @@
+package com.unifyworks.recipes;
+
+import com.unifyworks.UnifyWorks;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import net.neoforged.neoforge.registries.RegistryObject;
+
+/**
+ * Registration hub for UnifyWorks recipe serializers.
+ */
+public final class UWRecipes {
+    public static final DeferredRegister<RecipeSerializer<?>> SERIALIZERS =
+            DeferredRegister.create(NeoForgeRegistries.RECIPE_SERIALIZERS, UnifyWorks.MODID);
+
+    public static final RegistryObject<RecipeSerializer<CanonicalShapedRecipe>> CANONICAL_SHAPED =
+            SERIALIZERS.register("canonical_shaped", CanonicalShapedRecipe.Serializer::new);
+
+    public static final RegistryObject<RecipeSerializer<CanonicalShapelessRecipe>> CANONICAL_SHAPELESS =
+            SERIALIZERS.register("canonical_shapeless", CanonicalShapelessRecipe.Serializer::new);
+
+    private UWRecipes() {
+    }
+}


### PR DESCRIPTION
## Summary
- add a CanonicalAPI that exposes canonical material resolution, stack canonicalization, and helper metadata for other mods
- register canonical shaped and shapeless recipe serializers and optionally emit them from our datagen recipes
- document canonical recipe usage and expand diagnostics with canonical item reporting

## Testing
- ./gradlew :compileJava *(fails: Gradle wrapper cannot download due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dee88264d08327bb49508af61847d9