### PR TITLE
Add datapack filters and overrides support

### DIFF
--- a/DOCS/datapack_filters_overrides.md
+++ b/DOCS/datapack_filters_overrides.md
@@ -1,0 +1,32 @@
+Datapack filters and overrides
+==============================
+
+UnifyWorks datapacks can disable materials or tweak their properties without editing the bundled `materials.json`.
+Two resource locations are inspected during the reload process:
+
+- `data/<namespace>/unify/filters.json` — global deny-lists and compression caps.
+- `data/<namespace>/unify/overrides/*.json` — per-material field overrides and additive aliases.
+
+Merge order
+-----------
+1. Base `materials.json` (v4 format).
+2. Every `filters.json`, processed by namespace and path in alphabetical order.
+3. Every override file, also processed by namespace/path order.
+
+Inside a single key the *last* datapack wins. Deny-lists are merged additively.
+`aliases_add` entries are appended uniquely; duplicates are ignored.
+
+Effects
+-------
+- `deny_materials` removes the material from the merged snapshot and all downstream systems.
+- `deny_stones` removes stone entries (used by worldgen + compression) without touching metals or gems.
+- `max_compression_tier` clamps the effective compression tier (min/max 1-9) after mod config is applied.
+- Material overrides can toggle booleans such as `unify`, `generate_ore`, `provide_nugget`, `provide_storage_block`,
+  add aliases, adjust mining properties, or flip ore variants.
+
+Diagnostics
+-----------
+- `/unifyworks diag materials` reports totals after filters/overrides and shows the effective compression tier cap.
+- `/unifyworks diag material <name>` prints the merged entry for a specific material, including aliases, tags,
+  ore variants, mining data, datapack override status, and canonical drop information.
+- `/unifyworks diag tags <name>` continues to show tag coverage for the merged snapshot.

--- a/DOCS/filters.schema.json
+++ b/DOCS/filters.schema.json
@@ -1,0 +1,7 @@
+{ "$schema": "https://json-schema.org/draft/2020-12/schema", "title": "UnifyWorks filters v1",
+  "type": "object", "required": ["version"], "properties": {
+    "version": {"const": 1},
+    "deny_materials": {"type": "array", "items": {"type": "string", "pattern": "^[a-z0-9_]+$"}},
+    "deny_stones": {"type": "array", "items": {"type": "string", "pattern": "^[a-z0-9_]+$"}},
+    "max_compression_tier": {"type": "integer", "minimum": 1, "maximum": 9}
+  }, "additionalProperties": true }

--- a/DOCS/overrides.schema.json
+++ b/DOCS/overrides.schema.json
@@ -1,0 +1,21 @@
+{ "$schema": "https://json-schema.org/draft/2020-12/schema", "title": "UnifyWorks overrides v1",
+  "type": "object", "required": ["version", "name"], "properties": {
+    "version": {"const": 1},
+    "name": {"type": "string", "pattern": "^[a-z0-9_]+$"},
+    "provide_nugget": {"type": "boolean"},
+    "provide_storage_block": {"type": "boolean"},
+    "generate_ore": {"type": "boolean"},
+    "unify": {"type": "boolean"},
+    "aliases_add": {"type": "array", "items": {"type": "string", "pattern": "^[a-z0-9_]+$"}, "uniqueItems": true},
+    "mining": {"type": "object", "properties": {
+      "ore_level": {"enum": ["stone", "iron", "diamond", "netherite"]},
+      "block_level": {"enum": ["stone", "iron", "diamond", "netherite"]},
+      "ore_hardness": {"type": "number", "minimum": 0},
+      "block_hardness": {"type": "number", "minimum": 0}
+    }, "additionalProperties": false},
+    "variants": {"type": "object", "properties": {
+      "stone": {"type": "boolean"},
+      "deepslate": {"type": "boolean"},
+      "netherrack": {"type": "boolean"}
+    }, "additionalProperties": false}
+  }, "additionalProperties": true }

--- a/examples/datapack/unifyworks_filters_example/data/example/unify/filters.json
+++ b/examples/datapack/unifyworks_filters_example/data/example/unify/filters.json
@@ -1,0 +1,1 @@
+{ "version": 1, "deny_materials": ["aluminum", "lapis_lazuli"], "deny_stones": ["andesite"], "max_compression_tier": 7 }

--- a/examples/datapack/unifyworks_overrides_example/data/example/unify/overrides/osmium.json
+++ b/examples/datapack/unifyworks_overrides_example/data/example/unify/overrides/osmium.json
@@ -1,0 +1,1 @@
+{ "version": 1, "name": "osmium", "aliases_add": ["os"], "mining": { "ore_level": "iron", "block_level": "stone", "ore_hardness": 3.0, "block_hardness": 5.0 } }

--- a/src/main/java/com/unifyworks/UnifyWorks.java
+++ b/src/main/java/com/unifyworks/UnifyWorks.java
@@ -61,7 +61,8 @@ public class UnifyWorks {
                 compressionSnapshot.stones.addAll(snap.stones);
             }
 
-            UWCompressed.bootstrap(compressionSnapshot, UWConfig.maxTier());
+            int tier = Math.min(UWConfig.maxTier(), snap.maxCompressionTier());
+            UWCompressed.bootstrap(compressionSnapshot, tier);
         }
 
         modBus.addListener(this::onCommonSetup);

--- a/tools/validate_filters_overrides.js
+++ b/tools/validate_filters_overrides.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+
+const ajv = new Ajv({allErrors: true, strict: false});
+
+const readJSON = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
+const root = process.cwd();
+const filtersSchema = readJSON(path.join(root, 'DOCS', 'filters.schema.json'));
+const overridesSchema = readJSON(path.join(root, 'DOCS', 'overrides.schema.json'));
+const validateFilters = ajv.compile(filtersSchema);
+const validateOverrides = ajv.compile(overridesSchema);
+
+const scanJSON = (dir) => {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...scanJSON(full));
+    } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+const dataRoot = path.join('src', 'main', 'resources', 'data');
+const filters = scanJSON(dataRoot).filter(p => p.endsWith(path.join('unify', 'filters.json')));
+const overrides = scanJSON(dataRoot).filter(p => p.includes(path.join('unify', 'overrides')));
+
+let ok = true;
+for (const file of filters) {
+  try {
+    const payload = readJSON(file);
+    if (!validateFilters(payload)) {
+      console.error('[filters]', file, validateFilters.errors);
+      ok = false;
+    }
+  } catch (err) {
+    console.error('[filters]', file, err.message);
+    ok = false;
+  }
+}
+
+for (const file of overrides) {
+  try {
+    const payload = readJSON(file);
+    if (!validateOverrides(payload)) {
+      console.error('[overrides]', file, validateOverrides.errors);
+      ok = false;
+    }
+  } catch (err) {
+    console.error('[overrides]', file, err.message);
+    ok = false;
+  }
+}
+
+if (!ok) {
+  process.exit(1);
+}
+
+console.log('filters/overrides look valid.');


### PR DESCRIPTION
## Summary
- add a merge layer in `MaterialsIndex` so datapack filters and overrides can shape the unified material snapshot
- wire the merged snapshot through `UnifyDataReload`, diagnostics, and compression bootstrap so runtime systems see datapack changes
- document the formats, provide JSON schemas, sample datapacks, and a validation helper script

## Testing
- `./gradlew compileJava --offline` *(fails: net.neoforged.gradle.userdev plugin not available offline)*

------
https://chatgpt.com/codex/tasks/task_e_68deef4f19e48327887a5895feb4d6e2