### PR TITLE
Add placeholder guards and CI validator workflow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+scripts/assert-no-placeholders.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,32 @@
+name: validate
+on:
+  pull_request:
+  push:
+    branches: [ main, master ]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - name: Install validators
+        run: |
+          npm init -y >/dev/null 2>&1 || true
+          npm install ajv@8 --no-audit --no-fund
+      - name: Run validators
+        run: |
+          node tools/validate_materials.js
+          node tools/validate_filters_overrides.js
+          python3 tools/scan_assets.py
+          python3 scripts/assert-no-placeholders.py
+      - name: Generate reports
+        run: |
+          mkdir -p REPORTS
+          python3 tools/scan_assets.py > REPORTS/qa_scan.json || true
+          python3 tools/gen_placeholder_textures.py > REPORTS/placeholder_textures.json || true
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: unifyworks-reports
+          path: REPORTS/**

--- a/REPORTS/README.md
+++ b/REPORTS/README.md
@@ -7,3 +7,9 @@ If `qa_scan.json` contains issues:
 - Re-run `tools/gen_static_assets.py` after updating `materials.json`.
 - Manually add models/loot/tags for non-standard materials if needed.
 - Generate local 1×1 PNG placeholders with `python3 tools/gen_placeholder_textures.py --write` if you need temporary assets, but avoid committing the binaries.
+
+CI guardrails
+-------------
+- `scripts/assert-no-placeholders.py` fails CI and pre-commit if 1×1 placeholder PNGs or `*_placeholder.png` are present.
+- Install the local git hook: `bash scripts/install-git-hooks.sh`.
+- CI runs validators and uploads `REPORTS/qa_scan.json` and `REPORTS/placeholder_textures.json` generated in dry-run mode.

--- a/scripts/assert-no-placeholders.py
+++ b/scripts/assert-no-placeholders.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import sys, hashlib, base64, json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PNG_1x1_BYTES = base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=")
+PNG_1x1_SHA256 = hashlib.sha256(PNG_1x1_BYTES).hexdigest()
+
+violations = []
+for p in ROOT.rglob("*.png"):
+    if any(part in {"build", ".gradle", ".git"} for part in p.parts):
+        continue
+    try:
+        data = p.read_bytes()
+    except Exception:
+        continue
+    if len(data) <= 100 and hashlib.sha256(data).hexdigest() == PNG_1x1_SHA256:
+        violations.append(str(p.relative_to(ROOT)))
+    if p.name.endswith("_placeholder.png"):
+        violations.append(str(p.relative_to(ROOT)))
+
+if violations:
+    print("Placeholder PNGs detected (do not commit):")
+    print(json.dumps(violations, indent=2))
+    sys.exit(2)
+print("No placeholder PNGs detected.")

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "$0")/.." && pwd)"
+mkdir -p "$root/.git/hooks"
+cp "$root/.githooks/pre-commit" "$root/.git/hooks/pre-commit"
+chmod +x "$root/.git/hooks/pre-commit"
+echo "Installed pre-commit hook."


### PR DESCRIPTION
## Summary
- add a Python guard that blocks committing 1×1 placeholder PNGs and wire it into a pre-commit hook installer
- document the new guardrails in REPORTS/README.md for reference
- add a CI workflow that runs the existing validators, enforces the guard, and uploads REPORTS artifacts

## Testing
- scripts/assert-no-placeholders.py

------
https://chatgpt.com/codex/tasks/task_e_68df31fb9f6c8327b44aae80e4470b6b